### PR TITLE
feat(scan): discover GAPDoc bibliography declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Custom styles can be added by extending `require("blink-cmp-bibtex").setup()` wi
 - GAPDoc `<Bibliography Databases="manual, gapdoc"/>` declarations are scanned in
   XML documents. Names are comma-separated and carry no `.bib` extension, which
   is appended automatically; `.xml` (BibXMLext) databases are skipped, as are
-  declarations inside XML comments.
+  declarations inside XML comments, CDATA sections and processing instructions.
 - Both BibTeX (`.bib`) and Hayagriva (`.yml`, `.yaml`) bibliography files are supported and automatically detected based on file extension.
 - `opts.search_paths` accepts either file paths or glob patterns relative to the
   detected project root (based on `opts.root_markers`). These are treated as

--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ Custom styles can be added by extending `require("blink-cmp-bibtex").setup()` wi
 - Typst `#bibliography()` declarations are detected, including those in imported files via `#import` statements.
 - GAPDoc `<Bibliography Databases="manual, gapdoc"/>` declarations are scanned in
   XML documents. Names are comma-separated and carry no `.bib` extension, which
-  is appended automatically; `.xml` (BibXMLext) databases are skipped.
+  is appended automatically; `.xml` (BibXMLext) databases are skipped, as are
+  declarations inside XML comments.
 - Both BibTeX (`.bib`) and Hayagriva (`.yml`, `.yaml`) bibliography files are supported and automatically detected based on file extension.
 - `opts.search_paths` accepts either file paths or glob patterns relative to the
   detected project root (based on `opts.root_markers`). These are treated as

--- a/README.md
+++ b/README.md
@@ -211,13 +211,13 @@ in the default `filetypes`. Adding them is all the configuration needed:
 require("blink-cmp-bibtex").setup({
   -- `filetypes` is a list, so repeat the defaults you still want.
   filetypes = { "tex", "plaintex", "markdown", "rmd", "typst", "gap", "xml" },
-  -- GAPDoc's <Bibliography Databases="..."/> is not scanned, so point at the
-  -- bibliography explicitly.
-  files = { "doc/manual.bib" },
 })
 ```
 
-Typing `<Cite Key="CR` then completes the key, and `"` opens the menu.
+Typing `<Cite Key="CR` then completes the key, and `"` opens the menu. The
+document's own `<Bibliography Databases="..."/>` declaration is scanned, so the
+bibliography needs no configuration; `files` and `search_paths` remain available
+for bibliographies that live elsewhere.
 
 If your citation syntax differs, register your own matcher instead:
 
@@ -335,6 +335,9 @@ Custom styles can be added by extending `require("blink-cmp-bibtex").setup()` wi
 - Markdown YAML metadata lines such as `bibliography: references.bib` are
   respected.
 - Typst `#bibliography()` declarations are detected, including those in imported files via `#import` statements.
+- GAPDoc `<Bibliography Databases="manual, gapdoc"/>` declarations are scanned in
+  XML documents. Names are comma-separated and carry no `.bib` extension, which
+  is appended automatically; `.xml` (BibXMLext) databases are skipped.
 - Both BibTeX (`.bib`) and Hayagriva (`.yml`, `.yaml`) bibliography files are supported and automatically detected based on file extension.
 - `opts.search_paths` accepts either file paths or glob patterns relative to the
   detected project root (based on `opts.root_markers`). These are treated as
@@ -465,9 +468,18 @@ add `gap`, `xml` or `autodoc` to `filetypes` — see
 [Custom citation matchers](#custom-citation-matchers). Typing `"` opens the
 menu, and keys are inserted verbatim (no multi-key splitting).
 
-Bibliography discovery is not implemented for GAPDoc: the
-`<Bibliography Databases="manual"/>` declaration is not scanned. List the
-bibliography under `files` or `search_paths` instead.
+The bibliography is discovered from the document itself. A declaration such as
+
+```xml
+<Bibliography Databases="manual, gapdoc" Style="alpha"/>
+```
+
+resolves to `manual.bib` and `gapdoc.bib` next to the document, following
+GAPDoc's rule that BibTeX databases are named without their `.bib` extension.
+The optional `Style` attribute is ignored, and BibXMLext databases (named with
+their full `.xml` name) are skipped, since this plugin reads BibTeX and
+Hayagriva. If your bibliography lives elsewhere, list it under `files` or
+`search_paths` as usual.
 
 ### Completion details
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -455,7 +455,9 @@ BibTeX file discovery and path resolution.
 
 ### `scan.find_bib_files_from_buffer(bufnr)`
 
-Find BibTeX files referenced in a buffer.
+Find BibTeX files referenced in a buffer, from LaTeX commands, Markdown YAML
+front matter, Typst `#bibliography()` declarations and GAPDoc `<Bibliography>`
+declarations. See [Buffer Discovery](#buffer-discovery) for the exact forms.
 
 **Parameters:**
 - `bufnr` (number): Buffer number
@@ -659,5 +661,16 @@ The plugin automatically discovers BibTeX files from:
    ---
    ```
 
-3. **Configured search paths** relative to project root
-4. **Manual file paths** from configuration
+3. **Typst declarations** in `.typ` files:
+   - `#bibliography("refs.bib")`, including declarations inside `#import`ed files
+
+4. **GAPDoc declarations** in XML documents:
+   ```xml
+   <Bibliography Databases="manual, gapdoc" Style="alpha"/>
+   ```
+   Names are comma-separated and given without the `.bib` extension, which is
+   appended automatically. `Style` is ignored, and BibXMLext databases (named
+   with their full `.xml` name) are skipped.
+
+5. **Configured search paths** relative to project root
+6. **Manual file paths** from configuration

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -11,6 +11,9 @@ nvim-cmp) with a fresh, MIT-licensed codebase that targets blink.cmp directly.
 - Discover BibTeX files via multiple mechanisms:
   - `\addbibresource{}` declarations in the current buffer.
   - YAML metadata in Markdown (e.g. `bibliography: references.bib`).
+  - Typst `#bibliography()` declarations, including those in imported files.
+  - GAPDoc `<Bibliography Databases="..."/>` declarations, whose comma-separated
+    names carry no `.bib` extension.
   - Glob search relative to the project root (`opts.search_paths`).
   - Manually supplied file list via `opts.files`.
   - Resolve buffer-discovered paths relative to the buffer's directory, with the

--- a/lua/blink-cmp-bibtex/scan.lua
+++ b/lua/blink-cmp-bibtex/scan.lua
@@ -441,9 +441,16 @@ local function strip_inactive_regions(text)
   text = text:gsub('<!%-%-.-%-%->', ' ')
   text = text:gsub('<!%[CDATA%[.-%]%]>', ' ')
   text = text:gsub('<%?.-%?>', ' ')
+  -- A DOCTYPE may carry an internal subset, whose entity declarations hold
+  -- replacement text that is not markup until an entity is referenced. The
+  -- '[^>%[]*' guard keeps this from reaching past the DOCTYPE's own '>' into a
+  -- later element that happens to contain brackets.
+  text = text:gsub('<!DOCTYPE[^>%[]*%[.-%]%s*>', ' ')
+  text = text:gsub('<!DOCTYPE[^>]*>', ' ')
   text = text:gsub('<!%-%-.*$', ' ')
   text = text:gsub('<!%[CDATA%[.*$', ' ')
   text = text:gsub('<%?.*$', ' ')
+  text = text:gsub('<!DOCTYPE.*$', ' ')
   return text
 end
 

--- a/lua/blink-cmp-bibtex/scan.lua
+++ b/lua/blink-cmp-bibtex/scan.lua
@@ -418,6 +418,33 @@ local function expand_search_path(path, root)
   return resolved
 end
 
+--- Find bibliography databases in GAPDoc <Bibliography Databases="..."/> declarations
+--- Per the GAPDoc DTD the element is EMPTY with a required Databases attribute
+--- and an optional Style attribute; several databases are separated by commas.
+--- BibTeX databases are named without their .bib extension, while BibXMLext
+--- databases carry their full .xml name and are skipped here, since this plugin
+--- reads BibTeX and Hayagriva rather than BibXMLext.
+--- @param lines string[] Buffer lines to search
+--- @return string[] List of database names, without extensions
+local function find_gapdoc_bibliography(lines)
+  -- Joined so that a declaration split across lines is still found; the
+  -- attribute pattern cannot cross a '>' and so cannot leave its own element.
+  local text = table.concat(lines, '\n')
+  local resources = {}
+  local function collect(pattern)
+    for databases in text:gmatch(pattern) do
+      for _, name in ipairs(split_resources(databases)) do
+        if not name:lower():match('%.xml$') then
+          resources[#resources + 1] = name
+        end
+      end
+    end
+  end
+  collect('<Bibliography%s+[^>]-Databases%s*=%s*"([^"]*)"')
+  collect("<Bibliography%s+[^>]-Databases%s*=%s*'([^']*)'")
+  return resources
+end
+
 --- Ensure a path has a bibliography extension (.bib, .yml, or .yaml)
 --- @param path string|nil The path to check
 --- @return string|nil The path with .bib extension if needed (unless it already has .yml or .yaml)
@@ -470,6 +497,10 @@ function M.find_bib_files_from_buffer(bufnr)
   end
   local typst_resources = find_typst_bibliography(lines, buffer_dir)
   for _, resource in ipairs(typst_resources) do
+    resources[#resources + 1] = ensure_bib_extension(resource)
+  end
+  local gapdoc_resources = find_gapdoc_bibliography(lines)
+  for _, resource in ipairs(gapdoc_resources) do
     resources[#resources + 1] = ensure_bib_extension(resource)
   end
   return resources

--- a/lua/blink-cmp-bibtex/scan.lua
+++ b/lua/blink-cmp-bibtex/scan.lua
@@ -425,17 +425,40 @@ end
 --- databases carry their full .xml name and are skipped here, since this plugin
 --- reads BibTeX and Hayagriva rather than BibXMLext.
 --- @param lines string[] Buffer lines to search
---- @return string[] List of database names, without extensions
+--- @return string[] File names as written in the Databases attribute with '.bib'
+---   appended; entries may carry a directory part and may contain dots
 local function find_gapdoc_bibliography(lines)
+  -- Every buffer is scanned regardless of filetype, so the cost of joining the
+  -- lines is only paid once a declaration can actually be present.
+  local marked = false
+  for _, line in ipairs(lines) do
+    if line:find('<Bibliography', 1, true) then
+      marked = true
+      break
+    end
+  end
+  if not marked then
+    return {}
+  end
+
   -- Joined so that a declaration split across lines is still found; the
   -- attribute pattern cannot cross a '>' and so cannot leave its own element.
   local text = table.concat(lines, '\n')
+  -- Commented-out declarations name retired bibliographies. Replaced by a space
+  -- rather than removed so that surrounding markup cannot be glued together.
+  text = text:gsub('<!%-%-.-%-%->', ' ')
+  -- An unterminated comment opener comments out the rest of the document.
+  text = text:gsub('<!%-%-.*$', ' ')
+
   local resources = {}
   local function collect(pattern)
     for databases in text:gmatch(pattern) do
       for _, name in ipairs(split_resources(databases)) do
+        -- BibXMLext databases carry their full .xml name and are skipped; every
+        -- other name is a BibTeX database, which the DTD defines as being
+        -- written without its .bib extension, so it is always appended.
         if not name:lower():match('%.xml$') then
-          resources[#resources + 1] = name
+          resources[#resources + 1] = name .. '.bib'
         end
       end
     end
@@ -499,9 +522,11 @@ function M.find_bib_files_from_buffer(bufnr)
   for _, resource in ipairs(typst_resources) do
     resources[#resources + 1] = ensure_bib_extension(resource)
   end
+  -- Already carries its .bib extension: GAPDoc names are extensionless by
+  -- definition, so ensure_bib_extension's dotted-name heuristics do not apply.
   local gapdoc_resources = find_gapdoc_bibliography(lines)
   for _, resource in ipairs(gapdoc_resources) do
-    resources[#resources + 1] = ensure_bib_extension(resource)
+    resources[#resources + 1] = resource
   end
   return resources
 end

--- a/lua/blink-cmp-bibtex/scan.lua
+++ b/lua/blink-cmp-bibtex/scan.lua
@@ -424,6 +424,36 @@ end
 --- BibTeX databases are named without their .bib extension, while BibXMLext
 --- databases carry their full .xml name and are skipped here, since this plugin
 --- reads BibTeX and Hayagriva rather than BibXMLext.
+--- The opening of a GAPDoc bibliography declaration
+--- @type string
+local BIBLIOGRAPHY_TAG = '<Bibliography'
+
+--- Blank out the XML regions whose contents are not live markup
+--- Comments, CDATA sections and processing instructions all hold text that an
+--- XML processor never reads as markup, so a declaration inside one names a
+--- bibliography that is not in use. An unterminated opener runs to the end of
+--- the document, which is what an editor shows while such a region is being
+--- typed. Regions are replaced by a space rather than removed so that the
+--- markup around them cannot be glued together.
+--- @param text string The document text
+--- @return string The text with inactive regions blanked out
+local function strip_inactive_regions(text)
+  text = text:gsub('<!%-%-.-%-%->', ' ')
+  text = text:gsub('<!%[CDATA%[.-%]%]>', ' ')
+  text = text:gsub('<%?.-%?>', ' ')
+  text = text:gsub('<!%-%-.*$', ' ')
+  text = text:gsub('<!%[CDATA%[.*$', ' ')
+  text = text:gsub('<%?.*$', ' ')
+  return text
+end
+
+--- Read the Databases attribute of a single <Bibliography> element
+--- @param element string The element text, from '<Bibliography' to its '>'
+--- @return string|nil The attribute value, or nil when the element has none
+local function read_databases_attribute(element)
+  return element:match('Databases%s*=%s*"([^"]*)"') or element:match("Databases%s*=%s*'([^']*)'")
+end
+
 --- @param lines string[] Buffer lines to search
 --- @return string[] File names as written in the Databases attribute with '.bib'
 ---   appended; entries may carry a directory part and may contain dots
@@ -432,7 +462,7 @@ local function find_gapdoc_bibliography(lines)
   -- lines is only paid once a declaration can actually be present.
   local marked = false
   for _, line in ipairs(lines) do
-    if line:find('<Bibliography', 1, true) then
+    if line:find(BIBLIOGRAPHY_TAG, 1, true) then
       marked = true
       break
     end
@@ -441,30 +471,34 @@ local function find_gapdoc_bibliography(lines)
     return {}
   end
 
-  -- Joined so that a declaration split across lines is still found; the
-  -- attribute pattern cannot cross a '>' and so cannot leave its own element.
-  local text = table.concat(lines, '\n')
-  -- Commented-out declarations name retired bibliographies. Replaced by a space
-  -- rather than removed so that surrounding markup cannot be glued together.
-  text = text:gsub('<!%-%-.-%-%->', ' ')
-  -- An unterminated comment opener comments out the rest of the document.
-  text = text:gsub('<!%-%-.*$', ' ')
+  -- Joined so that a declaration split across lines is still found.
+  local text = strip_inactive_regions(table.concat(lines, '\n'))
 
   local resources = {}
-  local function collect(pattern)
-    for databases in text:gmatch(pattern) do
-      for _, name in ipairs(split_resources(databases)) do
-        -- BibXMLext databases carry their full .xml name and are skipped; every
-        -- other name is a BibTeX database, which the DTD defines as being
-        -- written without its .bib extension, so it is always appended.
-        if not name:lower():match('%.xml$') then
-          resources[#resources + 1] = name .. '.bib'
-        end
+  -- One pass in source order, reading both attribute quote styles as they come,
+  -- so that the returned list follows the document rather than the quoting.
+  local cursor = 1
+  while true do
+    local start_pos = text:find(BIBLIOGRAPHY_TAG .. '%s', cursor)
+    if not start_pos then
+      break
+    end
+    local rest = text:sub(start_pos)
+    -- Bounded by the element's own '>', so a Databases attribute belonging to a
+    -- later element is never read. The second form covers an element still
+    -- being typed at the end of the document, where no '>' exists yet.
+    local element = rest:match('^<Bibliography%s[^>]*>') or rest:match('^<Bibliography%s[^>]*$')
+    local databases = element and read_databases_attribute(element)
+    for _, name in ipairs(databases and split_resources(databases) or {}) do
+      -- BibXMLext databases carry their full .xml name and are skipped; every
+      -- other name is a BibTeX database, which the DTD defines as being
+      -- written without its .bib extension, so it is always appended.
+      if not name:lower():match('%.xml$') then
+        resources[#resources + 1] = name .. '.bib'
       end
     end
+    cursor = start_pos + #BIBLIOGRAPHY_TAG
   end
-  collect('<Bibliography%s+[^>]-Databases%s*=%s*"([^"]*)"')
-  collect("<Bibliography%s+[^>]-Databases%s*=%s*'([^']*)'")
   return resources
 end
 

--- a/lua/blink-cmp-bibtex/scan.lua
+++ b/lua/blink-cmp-bibtex/scan.lua
@@ -454,6 +454,41 @@ local function strip_inactive_regions(text)
   return text
 end
 
+--- The character references XML predefines, which need no DTD declaration
+--- @type table<string, string>
+local xml_entities = {
+  amp = '&',
+  lt = '<',
+  gt = '>',
+  quot = '"',
+  apos = "'",
+}
+
+--- Resolve one XML character reference to the character it stands for
+--- @param reference string The reference body, without the '&' and ';'
+--- @return string|nil The character, or nil when the reference is not resolvable
+local function resolve_xml_reference(reference)
+  local code = tonumber(reference:match('^#[xX](%x+)$') or '', 16) or tonumber(reference:match('^#(%d+)$') or '')
+  if code then
+    if code < 1 or code > 0x10FFFF then
+      return nil
+    end
+    return vim.fn.nr2char(code, 1)
+  end
+  -- Entity names are case sensitive in XML, so they are looked up as written.
+  return xml_entities[reference]
+end
+
+--- Decode the XML character references in an attribute value
+--- An XML processor resolves these before GAPDoc ever sees the value, so this
+--- runs before the value is split on commas. References that are not the five
+--- predefined entities or a numeric escape are left as written.
+--- @param value string The raw attribute value
+--- @return string The decoded value
+local function decode_xml_references(value)
+  return (value:gsub('&(#?%w+);', resolve_xml_reference))
+end
+
 --- Read the Databases attribute of a single <Bibliography> element
 --- @param element string The element text, from '<Bibliography' to its '>'
 --- @return string|nil The attribute value, or nil when the element has none
@@ -496,6 +531,7 @@ local function find_gapdoc_bibliography(lines)
     -- being typed at the end of the document, where no '>' exists yet.
     local element = rest:match('^<Bibliography%s[^>]*>') or rest:match('^<Bibliography%s[^>]*$')
     local databases = element and read_databases_attribute(element)
+    databases = databases and decode_xml_references(databases)
     for _, name in ipairs(databases and split_resources(databases) or {}) do
       -- BibXMLext databases carry their full .xml name and are skipped; every
       -- other name is a BibTeX database, which the DTD defines as being

--- a/tests/fixtures/project/doc.xml
+++ b/tests/fixtures/project/doc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- GAPDoc-style document. Not yet consumed by the source; kept as a
-     fixture for manual inspection of GAPDoc citation syntax. -->
+<!-- GAPDoc-style document, used for citation matching and for bibliography
+     discovery from the <Bibliography> declaration below. -->
 <Book Name="ProjectDoc">
   <Chapter>
     <Heading>Introduction</Heading>
@@ -8,5 +8,5 @@
     As shown in <Cite Key="project2020"/> and <Cite Key="projectbook2018"/>,
     the result holds.
   </Chapter>
-  <Bibliography Databases="refs"/>
+  <Bibliography Databases="shared" Style="alpha"/>
 </Book>

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -262,10 +262,18 @@ describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
       { name = 'a comment', open = '<!--', close = '-->' },
       { name = 'a CDATA section', open = '<![CDATA[', close = ']]>' },
       { name = 'a processing instruction', open = '<?gapdoc', close = '?>' },
+      {
+        name = 'a DOCTYPE internal subset',
+        open = '<!DOCTYPE Book SYSTEM "gapdoc.dtd" [',
+        close = ']>',
+        -- An entity declaration parks the markup as replacement text, which is
+        -- inert until something references the entity.
+        wrapped = '<!DOCTYPE Book SYSTEM "gapdoc.dtd" [ <!ENTITY old "<Bibliography Databases=\'old\'/>"> ]>',
+      },
     }
 
     for _, region in ipairs(regions) do
-      local wrapped = region.open .. ' <Bibliography Databases="old"/> ' .. region.close
+      local wrapped = region.wrapped or (region.open .. ' <Bibliography Databases="old"/> ' .. region.close)
 
       it('ignores a declaration inside ' .. region.name, function()
         assert.are.same({}, discover({ wrapped }))
@@ -307,18 +315,37 @@ describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
         discover({ '<?xml version="1.0" encoding="UTF-8"?>', '<Bibliography Databases="mybib"/>' })
       )
     end)
-  end)
 
-  it('returns declarations in source order regardless of quote style', function()
-    assert.are.same(
-      { 'first.bib', 'second.bib', 'third.bib', 'fourth.bib' },
-      discover({
-        "<Bibliography Databases='first'/>",
-        '<Bibliography Databases="second"/>',
-        "<Bibliography Databases='third'/>",
-        '<Bibliography Databases="fourth"/>',
-      })
-    )
+    it('is unaffected by a DOCTYPE without an internal subset', function()
+      assert.are.same(
+        { 'mybib.bib' },
+        discover({ '<!DOCTYPE Book SYSTEM "gapdoc.dtd">', '<Bibliography Databases="mybib"/>' })
+      )
+    end)
+
+    it('does not let a subset-less DOCTYPE reach a later name containing brackets', function()
+      -- The internal-subset pattern must not scan past the DOCTYPE's own '>'
+      -- looking for a ']' that belongs to something else entirely.
+      assert.are.same(
+        { 'bib[1].bib' },
+        discover({ '<!DOCTYPE Book SYSTEM "gapdoc.dtd">', '<Bibliography Databases="bib[1]"/>' })
+      )
+    end)
+
+    it('reads a declaration in a document with a full GAPDoc prologue', function()
+      assert.are.same(
+        { 'manual.bib' },
+        discover({
+          '<?xml version="1.0" encoding="UTF-8"?>',
+          '<!DOCTYPE Book SYSTEM "gapdoc.dtd" [',
+          '  <!ENTITY GAP "<Package>GAP</Package>">',
+          ']>',
+          '<Book Name="Manual">',
+          '  <Bibliography Databases="manual"/>',
+          '</Book>',
+        })
+      )
+    end)
   end)
 
   it('does not join the buffer when no declaration marker is present', function()

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -244,4 +244,56 @@ describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
   it('does not read a Databases attribute from a following element', function()
     assert.are.same({}, discover({ '<Bibliography/> <Other Databases="mybib"/>' }))
   end)
+
+  it('appends .bib to a dotted name, which GAPDoc treats as extensionless', function()
+    assert.are.same({ 'references.v2.bib' }, discover({ '<Bibliography Databases="references.v2"/>' }))
+  end)
+
+  it('appends .bib even to a name that already spells it out', function()
+    -- Characterizes the rule rather than second-guessing it: GAPDoc itself
+    -- appends .bib to whatever is written, so 'refs.bib' names refs.bib.bib.
+    assert.are.same({ 'refs.bib.bib' }, discover({ '<Bibliography Databases="refs.bib"/>' }))
+  end)
+
+  it('ignores a declaration inside an XML comment', function()
+    assert.are.same({}, discover({ '<!-- <Bibliography Databases="old"/> -->' }))
+  end)
+
+  it('ignores a declaration inside a comment spanning several lines', function()
+    assert.are.same({}, discover({ '<!--', '  <Bibliography Databases="old"/>', '-->' }))
+  end)
+
+  it('still reads a live declaration following a commented-out one', function()
+    assert.are.same(
+      { 'current.bib' },
+      discover({ '<!-- <Bibliography Databases="old"/> -->', '<Bibliography Databases="current"/>' })
+    )
+  end)
+
+  it('ignores a declaration after an unterminated comment opener', function()
+    assert.are.same({}, discover({ '<!-- retired', '<Bibliography Databases="old"/>' }))
+  end)
+
+  it('does not join the buffer when no declaration marker is present', function()
+    -- The extractor runs for every filetype, so the scan must stay cheap in
+    -- buffers that cannot contain a declaration at all.
+    -- Counting the joins is the only way to observe the guard from outside,
+    -- so table.concat is stubbed for the duration of this test and restored
+    -- below even when an assertion fails.
+    local original = table.concat
+    local calls = 0
+    --- @diagnostic disable-next-line: duplicate-set-field
+    table.concat = function(...) -- luacheck: ignore
+      calls = calls + 1
+      return original(...)
+    end
+    local ok, err = pcall(function()
+      assert.are.same({ 'bib/refs.bib' }, discover({ '\\addbibresource{bib/refs.bib}' }))
+      assert.are.equal(0, calls, 'joined the buffer without a <Bibliography marker')
+      discover({ '<Bibliography Databases="mybib"/>' })
+      assert.is_true(calls > 0, 'never joined the buffer despite a marker')
+    end)
+    table.concat = original -- luacheck: ignore
+    assert.is_true(ok, tostring(err))
+  end)
 end)

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -55,8 +55,17 @@ describe('scan.resolve_bib_paths', function()
     }, paths)
   end)
 
+  it('resolves a GAPDoc <Bibliography> declaration', function()
+    -- Deliberate change: doc.xml used to stand in for a buffer without any
+    -- bibliography declaration, since its <Bibliography> element was not read.
+    local paths = scan.resolve_bib_paths(open_fixture('project/doc.xml', 'xml'), {})
+    assert.are.same({ helpers.fixture('project/shared.bib') }, paths)
+  end)
+
   it('finds nothing in a buffer without bibliography declarations', function()
-    assert.are.same({}, scan.resolve_bib_paths(open_fixture('project/doc.xml', 'xml'), {}))
+    local bufnr = helpers.make_buf({ lines = { '<Book Name="Empty"><Chapter/></Book>' }, filetype = 'xml' })
+    assert.are.same({}, scan.resolve_bib_paths(bufnr, {}))
+    vim.api.nvim_buf_delete(bufnr, { force = true })
   end)
 
   describe('with a scratch buffer', function()
@@ -174,5 +183,65 @@ describe('scan.resolve_option_list', function()
         error('boom')
       end)
     )
+  end)
+end)
+
+describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
+  --- Discover bibliography names from a one-off XML buffer.
+  --- @param lines string[]
+  --- @return string[]
+  local function discover(lines)
+    local bufnr = helpers.make_buf({ lines = lines, filetype = 'xml' })
+    local resources = scan.find_bib_files_from_buffer(bufnr)
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+    return resources
+  end
+
+  it('appends .bib to a single database name', function()
+    assert.are.same({ 'mybib.bib' }, discover({ '<Bibliography Databases="mybib"/>' }))
+  end)
+
+  it('splits several comma-separated databases and trims them', function()
+    assert.are.same({ 'gapdoc.bib', 'mybib.bib' }, discover({ '<Bibliography Databases="gapdoc, mybib"/>' }))
+  end)
+
+  it('reads a single-quoted attribute', function()
+    assert.are.same({ 'mybib.bib' }, discover({ "<Bibliography Databases='mybib'/>" }))
+  end)
+
+  it('ignores the optional Style attribute, before or after Databases', function()
+    assert.are.same({ 'mybib.bib' }, discover({ '<Bibliography Databases="mybib" Style="alpha"/>' }))
+    assert.are.same({ 'mybib.bib' }, discover({ '<Bibliography Style="alpha" Databases="mybib"/>' }))
+  end)
+
+  it('reads a declaration split across lines', function()
+    assert.are.same({ 'mybib.bib' }, discover({ '<Bibliography', '   Databases="mybib"/>' }))
+  end)
+
+  it('reads several declarations in one document', function()
+    assert.are.same(
+      { 'first.bib', 'second.bib' },
+      discover({ '<Bibliography Databases="first"/>', '<Bibliography Databases="second"/>' })
+    )
+  end)
+
+  it('keeps a database name that already carries a path', function()
+    assert.are.same({ 'bib/refs.bib' }, discover({ '<Bibliography Databases="bib/refs"/>' }))
+  end)
+
+  it('skips BibXMLext databases, which are named with their .xml extension', function()
+    assert.are.same({ 'mybib.bib' }, discover({ '<Bibliography Databases="mybib, gapdoc.xml"/>' }))
+  end)
+
+  it('does not match a different element with a similar name', function()
+    assert.are.same({}, discover({ '<BibliographyIndex Databases="mybib"/>' }))
+  end)
+
+  it('does not match a Cite element', function()
+    assert.are.same({}, discover({ '<Cite Key="mybib"/>' }))
+  end)
+
+  it('does not read a Databases attribute from a following element', function()
+    assert.are.same({}, discover({ '<Bibliography/> <Other Databases="mybib"/>' }))
   end)
 end)

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -348,6 +348,46 @@ describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
     end)
   end)
 
+  describe('character references', function()
+    local cases = {
+      { name = 'a named entity', written = 'references&amp;notes', expected = 'references&notes.bib' },
+      { name = 'a decimal reference', written = 'references&#38;notes', expected = 'references&notes.bib' },
+      { name = 'a lowercase hex reference', written = 'references&#x26;notes', expected = 'references&notes.bib' },
+      { name = 'an uppercase hex reference', written = 'references&#X26;notes', expected = 'references&notes.bib' },
+      { name = 'an apostrophe entity', written = 'o&apos;neill', expected = "o'neill.bib" },
+      { name = 'a quote entity', written = 'say&quot;what', expected = 'say"what.bib' },
+      { name = 'a non-ASCII reference', written = 'caf&#233;', expected = 'caf\u{e9}.bib' },
+    }
+
+    for _, case in ipairs(cases) do
+      it('decodes ' .. case.name, function()
+        assert.are.same({ case.expected }, discover({ '<Bibliography Databases="' .. case.written .. '"/>' }))
+      end)
+    end
+
+    it('leaves an undeclared entity as written', function()
+      assert.are.same({ 'refs&custom;more.bib' }, discover({ '<Bibliography Databases="refs&custom;more"/>' }))
+    end)
+
+    it('decodes before splitting, so an encoded comma separates names', function()
+      -- An XML processor resolves the reference first, and GAPDoc then splits
+      -- the decoded value, so this names two databases rather than one.
+      assert.are.same({ 'first.bib', 'second.bib' }, discover({ '<Bibliography Databases="first&#44;second"/>' }))
+    end)
+  end)
+
+  it('returns declarations in source order regardless of quote style', function()
+    assert.are.same(
+      { 'first.bib', 'second.bib', 'third.bib', 'fourth.bib' },
+      discover({
+        "<Bibliography Databases='first'/>",
+        '<Bibliography Databases="second"/>',
+        "<Bibliography Databases='third'/>",
+        '<Bibliography Databases="fourth"/>',
+      })
+    )
+  end)
+
   it('does not join the buffer when no declaration marker is present', function()
     -- The extractor runs for every filetype, so the scan must stay cheap in
     -- buffers that cannot contain a declaration at all.

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -255,23 +255,70 @@ describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
     assert.are.same({ 'refs.bib.bib' }, discover({ '<Bibliography Databases="refs.bib"/>' }))
   end)
 
-  it('ignores a declaration inside an XML comment', function()
-    assert.are.same({}, discover({ '<!-- <Bibliography Databases="old"/> -->' }))
+  describe('inactive regions', function()
+    -- A declaration inside a region an XML processor does not read as markup
+    -- names a bibliography that is not in use, whatever kind of region it is.
+    local regions = {
+      { name = 'a comment', open = '<!--', close = '-->' },
+      { name = 'a CDATA section', open = '<![CDATA[', close = ']]>' },
+      { name = 'a processing instruction', open = '<?gapdoc', close = '?>' },
+    }
+
+    for _, region in ipairs(regions) do
+      local wrapped = region.open .. ' <Bibliography Databases="old"/> ' .. region.close
+
+      it('ignores a declaration inside ' .. region.name, function()
+        assert.are.same({}, discover({ wrapped }))
+      end)
+
+      it('ignores a declaration inside ' .. region.name .. ' spanning several lines', function()
+        assert.are.same({}, discover({ region.open, '  <Bibliography Databases="old"/>', region.close }))
+      end)
+
+      it('still reads a live declaration before ' .. region.name, function()
+        assert.are.same({ 'current.bib' }, discover({ '<Bibliography Databases="current"/>', wrapped }))
+      end)
+
+      it('still reads a live declaration after ' .. region.name, function()
+        assert.are.same({ 'current.bib' }, discover({ wrapped, '<Bibliography Databases="current"/>' }))
+      end)
+
+      it('still reads live declarations on both sides of ' .. region.name, function()
+        assert.are.same(
+          { 'first.bib', 'second.bib' },
+          discover({ '<Bibliography Databases="first"/>', wrapped, '<Bibliography Databases="second"/>' })
+        )
+      end)
+
+      it('treats the rest of the document as inactive after an unterminated ' .. region.name, function()
+        -- Documented behavior: an opener without its closer runs to the end of
+        -- the document, which is what the region looks like while it is typed.
+        assert.are.same({}, discover({ region.open .. ' retired', '<Bibliography Databases="old"/>' }))
+      end)
+    end
+
+    it('reads a declaration before an unterminated region', function()
+      assert.are.same({ 'current.bib' }, discover({ '<Bibliography Databases="current"/>', '<!-- retired' }))
+    end)
+
+    it('is unaffected by the XML declaration of a normal document', function()
+      assert.are.same(
+        { 'mybib.bib' },
+        discover({ '<?xml version="1.0" encoding="UTF-8"?>', '<Bibliography Databases="mybib"/>' })
+      )
+    end)
   end)
 
-  it('ignores a declaration inside a comment spanning several lines', function()
-    assert.are.same({}, discover({ '<!--', '  <Bibliography Databases="old"/>', '-->' }))
-  end)
-
-  it('still reads a live declaration following a commented-out one', function()
+  it('returns declarations in source order regardless of quote style', function()
     assert.are.same(
-      { 'current.bib' },
-      discover({ '<!-- <Bibliography Databases="old"/> -->', '<Bibliography Databases="current"/>' })
+      { 'first.bib', 'second.bib', 'third.bib', 'fourth.bib' },
+      discover({
+        "<Bibliography Databases='first'/>",
+        '<Bibliography Databases="second"/>',
+        "<Bibliography Databases='third'/>",
+        '<Bibliography Databases="fourth"/>',
+      })
     )
-  end)
-
-  it('ignores a declaration after an unterminated comment opener', function()
-    assert.are.same({}, discover({ '<!-- retired', '<Bibliography Databases="old"/>' }))
   end)
 
   it('does not join the buffer when no declaration marker is present', function()

--- a/tests/source_spec.lua
+++ b/tests/source_spec.lua
@@ -182,7 +182,15 @@ describe('Source GAPDoc support', function()
 
   it('completes citation keys inside <Cite Key="', function()
     local response = complete(source, helpers.ctx('As shown in <Cite Key="', nil, bufnr))
-    assert.are.same({ 'project2020', 'projectbook2018' }, vim.fn.sort(labels(response)))
+    -- shared2015 comes from the <Bibliography Databases="shared"/> declaration
+    -- in doc.xml, which is discovered from the buffer, not from opts.files.
+    assert.are.same({ 'project2020', 'projectbook2018', 'shared2015' }, vim.fn.sort(labels(response)))
+  end)
+
+  it('completes from the declared bibliography without any configured files', function()
+    local discovered = Source.new({ files = {}, filetypes = { 'gap' } })
+    local response = complete(discovered, helpers.ctx('<Cite Key="shared', nil, bufnr))
+    assert.are.same({ 'shared2015' }, labels(response))
   end)
 
   it('filters by the typed prefix', function()


### PR DESCRIPTION
Ref: #20.

GAPDoc documents declare their BibTeX databases with `<Bibliography Databases="gapdoc, mybib"/>`. scan.lua now picks these up, alongside the existing `\addbibresource`, YAML and Typst discovery, so a GAPDoc buffer completes citations without any `files` or `search_paths` configuration.

Semantics follow the [GAPDoc manual (chapter 3)](https://docs.gap-system.org/pkg/gapdoc/doc/chap3.html): comma-separated names, BibTeX files given without the `.bib` extension, BibXMLext entries (full `.xml` names) skipped since the parser does not read that format. The `Style` attribute is ignored.