### PR TITLE
feat(scan): user-extensible bib discovery hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,18 +31,21 @@ nvim -u repro.lua   # clean Neovim with blink.cmp and this plugin only
 
 ## Architecture
 
-Eight modules under `lua/blink-cmp-bibtex/`:
+Eleven modules under `lua/blink-cmp-bibtex/`:
 
 1. **config.lua** - Default settings, `setup()` and `extend()` functions for configuration. List options replace defaults; keyed maps are merged
 2. **parser.lua** - BibTeX/Hayagriva parsing with LaTeX accent normalization to UTF-8
-3. **scan.lua** - File discovery from `\addbibresource{}`, YAML metadata, Typst `#bibliography()`, `#import` statements, and glob patterns
+3. **scan.lua** - Path resolution: runs the discovery hooks for the buffer, then resolves, expands globs and deduplicates against `files`, `global_files` and `search_paths`
 4. **cache.lua** - Mtime-based caching of parsed entries
 5. **matchers.lua** - Citation matchers (`latex`, `pandoc`, `typst`, `gapdoc`), the shipped per-filetype dispatch (`M.defaults`, which config.lua copies), normalization of user-configured matchers, priority ordering and dispatch
 6. **local_bib.lua** - Local bibliography management (copy entries from global to project-local files)
-7. **health.lua** - `:checkhealth blink-cmp-bibtex`, reports the resolved config and matcher chains
-8. **init.lua** - blink.cmp source implementation (`Source:enabled`, `Source:get_trigger_characters`, `Source:get_completions`, `Source:resolve`, `Source:execute`)
+7. **health.lua** - `:checkhealth blink-cmp-bibtex`, reports the resolved config and both the matcher and discovery chains
+8. **discovery.lua** - Buffer bibliography discovery (`latex`, `yaml`, `typst`, `gapdoc` hooks), the shipped dispatch (`M.defaults`, which config.lua copies), normalization of user-configured hooks and chain execution
+9. **registry.lua** - Shared bookkeeping for both extension points: warn-once, error rendering and per-filetype failure tracking
+10. **path.lua** - Path helpers (`joinpath`, `normalize`, `is_absolute`) shared by scan.lua and discovery.lua
+11. **init.lua** - blink.cmp source implementation (`Source:enabled`, `Source:get_trigger_characters`, `Source:get_completions`, `Source:resolve`, `Source:execute`)
 
-**Data flow**: Buffer → scan.lua (file discovery) → cache.lua (mtime check) → parser.lua (parse if needed) → matchers.lua (citation prefix at cursor) → init.lua (format & filter) → blink.cmp
+**Data flow**: Buffer → discovery.lua (hooks report declared files) → scan.lua (resolve and deduplicate paths) → cache.lua (mtime check) → parser.lua (parse if needed) → matchers.lua (citation prefix at cursor) → init.lua (format & filter) → blink.cmp
 
 Entry point: `plugin/blink-cmp-bibtex.lua`
 

--- a/README.md
+++ b/README.md
@@ -155,10 +155,14 @@ Spec fields:
   one) – lower runs first; the first matcher that returns a result wins. Ties
   are broken by name.
 - `sanitize` (boolean) – whether a matched prefix is reduced to the key being
-  typed. Sanitization splits on `,`/`;`, keeps the last segment, trims
-  whitespace and strips a leading `@`, which is what makes `\cite{a,b,c` and
-  `[@a; @b` complete the final key. Set `sanitize = false` when keys are used
-  verbatim (the built-in `gapdoc` matcher does this).
+  typed. Sanitization splits on the matcher's separators, keeps the last
+  segment, trims whitespace and strips a leading `@`, which is what makes
+  `\cite{a,b,c` and `[@a; @b` complete the final key. Set `sanitize = false`
+  when keys are used verbatim (the built-in `gapdoc` matcher does this).
+- `separators` (string, default `",;"`) – the characters that separate keys in
+  a multi-key citation. The built-in `latex` and `typst` matchers use `","`
+  only, since a semicolon is an ordinary character in a key there; `pandoc`
+  uses `",;"`.
 - `trigger_characters` (string[]) – characters that should open the completion
   menu in buffers of this filetype. They are only offered while the source is
   enabled, so a `"` trigger for XML never fires in a LaTeX buffer.

--- a/README.md
+++ b/README.md
@@ -324,9 +324,14 @@ fields. Spec fields:
   Set `extension = false` when the hook returns finished file names.
 
 Relative paths are resolved against the buffer's directory, with the project
-root as a fallback, exactly like the built-in results. `discovery = false`
-turns buffer discovery off entirely, leaving `files`, `global_files` and
-`search_paths` as the only sources.
+root as a fallback, exactly like the built-in results.
+
+`discovery = false` turns buffer discovery off entirely, leaving `files`,
+`global_files` and `search_paths` as the only sources, and `discovery = true`
+restores the shipped hooks. The `matchers` option takes the same two
+shorthands. Any other value that is neither of those nor a table is reported
+through `vim.notify` once and ignored, so a typo degrades the configuration
+instead of breaking completion.
 
 Run `:checkhealth blink-cmp-bibtex` to see the discovery chain that a filetype
 actually resolves to.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Markdown and R Markdown buffers.
 
 ---
 
-[Features](#features) · [Installation](#installation) · [Configuration](#configuration) · [Custom citation matchers](#custom-citation-matchers) · [Usage](#usage) · [Health check](#health-check) · [Alternatives](#alternatives)
+[Features](#features) · [Installation](#installation) · [Configuration](#configuration) · [Custom citation matchers](#custom-citation-matchers) · [Custom bib discovery](#custom-bib-discovery) · [Usage](#usage) · [Health check](#health-check) · [Alternatives](#alternatives)
 
 ---
 
@@ -40,6 +40,9 @@ Markdown and R Markdown buffers.
   `require("blink-cmp-bibtex").setup()` or provider-level `opts`.
 - Lets you add citation syntaxes per filetype through the `matchers` option
   (GAPDoc's `<Cite Key="…"/>` is included), without patching the plugin.
+- Lets you add bibliography discovery for your own conventions through the
+  `discovery` option, alongside the built-in LaTeX, YAML, Typst and GAPDoc
+  declarations.
 - Reports the resolved configuration through `:checkhealth blink-cmp-bibtex`.
 
 ## Installation
@@ -247,6 +250,87 @@ require("blink-cmp-bibtex").setup({
 Run `:checkhealth blink-cmp-bibtex` to see the matcher chain that a filetype
 actually resolves to.
 
+### Custom bib discovery
+
+A *discovery hook* reads the current buffer and reports the bibliography files
+it declares. This is what finds `\addbibresource{refs.bib}` in a LaTeX file or
+`bibliography: refs.bib` in Markdown front matter, and it is the same kind of
+registry as the matchers above: the `discovery` option maps a filetype to the
+hooks that run in it, and `'*'` applies to every filetype.
+
+The defaults, which live in
+`require("blink-cmp-bibtex.discovery").defaults`, are:
+
+```lua
+discovery = {
+  ['*'] = {
+    latex = { priority = 10 },   -- \addbibresource{}, \bibliography{}
+    yaml = { priority = 20 },    -- bibliography: in Markdown front matter
+    typst = { priority = 30 },   -- #bibliography(), following #import
+    gapdoc = { priority = 40, extension = false }, -- <Bibliography Databases="">
+  },
+}
+```
+
+Note the contrast with `matchers`: **every** discovery hook sits under `'*'`,
+because a declaration is worth finding wherever it appears — an
+`\addbibresource` in a Markdown buffer is found today, and moving the LaTeX
+hook under `tex` would silently stop finding it. Only narrow a hook to a
+filetype when the syntax genuinely cannot occur elsewhere.
+
+A hook receives a context and returns the file names it found, as a list, a
+single string, or nil:
+
+```lua
+require("blink-cmp-bibtex").setup({
+  discovery = {
+    ['*'] = {
+      -- Read a project convention: a plain-text file listing bibliographies.
+      manifest = {
+        priority = 5,
+        find = function(ctx)
+          -- Cheap guard first: hooks run on every completion request, so scan
+          -- for a literal marker before doing anything expensive.
+          for _, line in ipairs(ctx.lines) do
+            local path = line:match('^%%%% bib: (.+)$')
+            if path then
+              return path
+            end
+          end
+          return nil
+        end,
+      },
+    },
+    -- Markdown documents in this project never use LaTeX declarations.
+    markdown = { latex = false },
+  },
+})
+```
+
+The context carries `bufnr`, `filetype`, `lines`, `bufname`, `dir` (the
+buffer's directory, for resolving relative paths) and `opts`. Its `lines` table
+is shared with the other hooks, so treat it as read-only.
+
+Values are normalized exactly as matcher values are — `false` disables, `true`
+enables the built-in of the same name, a string names a built-in, a function is
+the hook itself, and a table is a spec — with the same inheritance of shipped
+fields. Spec fields:
+
+- `find` (function) — the hook itself.
+- `priority` (number, default `50`) — lower runs first. Unlike matchers, every
+  hook runs; priority decides only the order of the results.
+- `extension` (boolean) — when not `false`, a name without an extension gets
+  `.bib` appended, so `\bibliography{references}` resolves to `references.bib`.
+  Set `extension = false` when the hook returns finished file names.
+
+Relative paths are resolved against the buffer's directory, with the project
+root as a fallback, exactly like the built-in results. `discovery = false`
+turns buffer discovery off entirely, leaving `files`, `global_files` and
+`search_paths` as the only sources.
+
+Run `:checkhealth blink-cmp-bibtex` to see the discovery chain that a filetype
+actually resolves to.
+
 ### Source indicators
 
 When you have both local (project) and global (shared) bibliography files,
@@ -340,6 +424,9 @@ Custom styles can be added by extending `require("blink-cmp-bibtex").setup()` wi
   is appended automatically; `.xml` (BibXMLext) databases are skipped, as are
   declarations inside XML comments, CDATA sections and processing instructions.
 - Both BibTeX (`.bib`) and Hayagriva (`.yml`, `.yaml`) bibliography files are supported and automatically detected based on file extension.
+- Every one of these is a discovery hook, and the set is configurable: see
+  [Custom bib discovery](#custom-bib-discovery) to add a syntax, reorder the
+  hooks, or disable one per filetype.
 - `opts.search_paths` accepts either file paths or glob patterns relative to the
   detected project root (based on `opts.root_markers`). These are treated as
   **local** sources.

--- a/docs/api.md
+++ b/docs/api.md
@@ -449,18 +449,109 @@ Parse a BibTeX file and return all entries.
 **Errors:**
 - Throws an error if the file cannot be opened
 
+## Module: blink-cmp-bibtex.discovery
+
+Bibliography discovery from the current buffer. A *hook* reads the buffer and
+reports the files it declares; the hooks that run in a filetype are configured
+through the `discovery` option, whose default is `discovery.defaults`.
+
+### `discovery.latex(ctx)` / `discovery.yaml(ctx)` / `discovery.typst(ctx)` / `discovery.gapdoc(ctx)`
+
+The hooks shipped with the plugin, reading `\addbibresource{}` and friends,
+Markdown YAML front matter, Typst `#bibliography()` (following `#import`), and
+GAPDoc `<Bibliography Databases="…"/>` respectively.
+
+**Parameters:**
+- `ctx` (BibtexDiscoveryContext): The buffer being scanned
+
+**Returns:**
+- `string[]`: File names, unresolved
+
+### `discovery.builtin`
+
+Table mapping the built-in names `latex`, `yaml`, `typst` and `gapdoc` to their
+functions.
+
+### `discovery.defaults`
+
+The dispatch shipped with the plugin, and the value `config` copies into
+`discovery`. Every hook sits under `'*'`: discovery is filetype agnostic, unlike
+`matchers.defaults`, where the filetype decides which citation syntax applies.
+
+### `discovery.normalize(name, value, filetype)`
+
+Normalize a configured value into a spec, accepting the same forms as
+`matchers.normalize` (`false`, `true`, a built-in name, a function, or a spec
+table) with the same inheritance of shipped fields. Invalid values are skipped
+with one warning per name.
+
+**Returns:**
+- `BibtexDiscoverySpec|nil`
+
+### `discovery.chain(filetype, opts)`
+
+Build the ordered hook chain for a filetype. Entries under the filetype key
+override same-named `'*'` entries; ties break on the name.
+
+Unlike `matchers.chain`, this falls back to `discovery.defaults` when `opts` or
+`opts.discovery` is absent, because `find_bib_files_from_buffer` is public and
+is called without options. Pass `discovery = false` to run no hooks at all.
+
+**Returns:**
+- `BibtexDiscoverySpec[]`
+
+### `discovery.collect(ctx)`
+
+Run the chain and concatenate what the hooks report, in chain order. Each hook
+is called inside `pcall`; one that raises, or returns something other than a
+string or a list of strings, is reported once and skipped for that filetype.
+Names are returned unresolved — `resolve_bib_paths` resolves and deduplicates
+them.
+
+**Returns:**
+- `string[]`
+
+### Types
+
+```lua
+--- @class BibtexDiscoveryContext
+--- @field bufnr number
+--- @field filetype string|nil
+--- @field lines string[]      -- shared between hooks; read-only
+--- @field bufname string|nil
+--- @field dir string|nil      -- the buffer's directory
+--- @field opts table
+
+--- @alias BibtexDiscoveryFn fun(ctx: BibtexDiscoveryContext): string[]|string|nil
+
+--- @class BibtexDiscoverySpec
+--- @field name string
+--- @field find BibtexDiscoveryFn
+--- @field priority number       -- lower runs first (default 50); output order only
+--- @field extension boolean|nil -- when not false, extensionless results get '.bib'
+```
+
+A hook takes only the context, with no leading subject argument. This differs
+from a matcher, which takes the text it inspects as its first parameter: the
+lines a hook reads are already part of its context.
+
 ## Module: blink-cmp-bibtex.scan
 
 BibTeX file discovery and path resolution.
 
-### `scan.find_bib_files_from_buffer(bufnr)`
+### `scan.find_bib_files_from_buffer(bufnr, opts)`
 
-Find BibTeX files referenced in a buffer, from LaTeX commands, Markdown YAML
-front matter, Typst `#bibliography()` declarations and GAPDoc `<Bibliography>`
-declarations. See [Buffer Discovery](#buffer-discovery) for the exact forms.
+Find BibTeX files referenced in a buffer by running the discovery hooks
+configured for its filetype. See [Buffer Discovery](#buffer-discovery) for the
+forms the built-in hooks understand, and
+[Module: blink-cmp-bibtex.discovery](#module-blink-cmp-bibtexdiscovery) for
+registering your own.
 
 **Parameters:**
 - `bufnr` (number): Buffer number
+- `opts` (table|nil): Configuration options. When omitted, the hooks shipped
+  with the plugin are used, so callers that only want the built-in behavior can
+  keep calling this with a buffer alone.
 
 **Returns:**
 - `string[]`: List of bibliography file names (not full paths)
@@ -674,3 +765,7 @@ The plugin automatically discovers BibTeX files from:
 
 5. **Configured search paths** relative to project root
 6. **Manual file paths** from configuration
+
+Items 1-4 are discovery hooks and can be reordered, disabled per filetype, or
+joined by your own; see
+[Module: blink-cmp-bibtex.discovery](#module-blink-cmp-bibtexdiscovery).

--- a/docs/api.md
+++ b/docs/api.md
@@ -495,7 +495,10 @@ override same-named `'*'` entries; ties break on the name.
 
 Unlike `matchers.chain`, this falls back to `discovery.defaults` when `opts` or
 `opts.discovery` is absent, because `find_bib_files_from_buffer` is public and
-is called without options. Pass `discovery = false` to run no hooks at all.
+is called without options. Pass `discovery = false` to run no hooks at all, or
+`discovery = true` for the shipped ones. A value that is neither a table nor
+one of those booleans is reported once and treated as absent; `matchers.chain`
+accepts the same shorthands, where absent means an empty chain.
 
 **Returns:**
 - `BibtexDiscoverySpec[]`

--- a/docs/development.md
+++ b/docs/development.md
@@ -401,13 +401,37 @@ citation_commands = {
 }
 ```
 
-### Adding File Discovery
+### Adding a discovery source
 
-Modify `scan.lua`:
+Bibliography discovery is a registry, so a new source is a hook rather than an
+edit to the scanner. Add it to `discovery.lua` next to the built-ins, list it in
+`discovery.builtin` and `discovery.defaults`, and give it a priority that places
+its results where you want them in the output.
 
-1. Add pattern matching in `extract_command_paths` for LaTeX
-2. Add parsing in `find_yaml_bibliography` for Markdown
-3. Update documentation
+```lua
+--- @param ctx BibtexDiscoveryContext
+--- @return string[]
+function M.mysource(ctx)
+  ...
+end
+```
+
+Three things to keep in mind:
+
+1. **Hooks run on every completion request**, once per keystroke in the worst
+   case. Guard expensive work behind a cheap scan for a literal marker, the way
+   the GAPDoc hook checks for `<Bibliography` with a plain-text `find` before
+   joining the buffer.
+2. **The `lines` table is shared** with the other hooks. Treat it as read-only;
+   do not sort it, and do not copy it per hook.
+3. **Return unresolved names.** `resolve_bib_paths` resolves them against the
+   buffer directory and project root and deduplicates the result. Set
+   `extension = false` in the spec if your hook returns finished file names
+   rather than the extensionless form.
+
+Users register hooks the same way through the `discovery` option, so anything
+you can do here they can do without patching the plugin. Update the README's
+"Custom bib discovery" section and `docs/api.md` when the built-in set changes.
 
 ## Debugging
 

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -210,6 +210,24 @@ end
 2. User's own configuration
 3. Files in project directory
 
+### 4. User-registered matchers and discovery hooks
+
+**Concern**: The `matchers` and `discovery` options accept Lua functions, which
+the plugin then calls.
+
+**Mitigation**:
+- These functions come from the user's own configuration, which Neovim already
+  executes in full. They are inside the trust boundary, not outside it: a
+  configuration that can register a hook can equally call anything directly.
+- The plugin does not load, evaluate or fetch matcher or hook code of its own;
+  it only calls what the configuration handed it.
+- Every call is wrapped in `pcall`, and a function that raises or returns a
+  malformed value is reported once and then skipped for that filetype, so a
+  faulty hook degrades completion rather than breaking the editor.
+
+**Assessment**: No new attack surface. The trust boundary is unchanged from a
+plain `setup()` call.
+
 ## Security Best Practices Followed
 
 1. ✅ Principle of least privilege (read-only file access)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -48,6 +48,9 @@ nvim-cmp) with a fresh, MIT-licensed codebase that targets blink.cmp directly.
   disable completion as a whole.
 - Provide asynchronous completion so that large BibTeX files do not block the UI.
 - Cache parsed BibTeX files and reload them when the modification time changes.
+- Allow bibliography discovery to be extended: a user must be able to register a
+  hook for a project convention the plugin does not know, reorder the built-in
+  hooks, or disable one per filetype, without patching the plugin.
 
 ## Non-functional requirements
 
@@ -57,7 +60,12 @@ nvim-cmp) with a fresh, MIT-licensed codebase that targets blink.cmp directly.
   - `config.lua`: defaults plus `setup` and merge helpers.
   - `parser.lua`: standalone BibTeX parser that extracts entry metadata and
     performs minimal LaTeX-to-UTF8 conversions.
-  - `scan.lua`: buffer/project inspectors that find relevant `.bib` files.
+  - `scan.lua`: path resolution for the files discovery and configuration name.
+  - `discovery.lua`: built-in buffer discovery hooks plus the normalization and
+    dispatch of user-registered ones.
+  - `registry.lua`: warn-once and failure tracking shared by the matcher and
+    discovery registries.
+  - `path.lua`: path helpers shared by the scanner and the discovery hooks.
   - `cache.lua`: memoized storage keyed by file path with mtime checks.
   - `matchers.lua`: built-in citation matchers plus the normalization and
     dispatch of user-registered ones.

--- a/lua/blink-cmp-bibtex/config.lua
+++ b/lua/blink-cmp-bibtex/config.lua
@@ -2,6 +2,7 @@
 --- Manages default settings and allows customization through setup() and extend()
 --- @module 'blink-cmp-bibtex.config'
 
+local discovery = require('blink-cmp-bibtex.discovery')
 local matchers = require('blink-cmp-bibtex.matchers')
 
 local M = {}
@@ -25,6 +26,10 @@ local defaults = {
     'citep',
     'citet',
   },
+  -- Bibliography discovery hooks per filetype. Entries under a filetype key
+  -- override same-named entries under '*'. Unlike the matchers, every shipped
+  -- hook sits under '*', because buffer discovery is filetype agnostic.
+  discovery = vim.deepcopy(discovery.defaults),
   -- Citation matchers per filetype. Entries under a filetype key override
   -- same-named entries under '*'. The shipped dispatch and the accepted entry
   -- forms both live in matchers.lua, which owns this default.

--- a/lua/blink-cmp-bibtex/config.lua
+++ b/lua/blink-cmp-bibtex/config.lua
@@ -3,6 +3,7 @@
 --- @module 'blink-cmp-bibtex.config'
 
 local discovery = require('blink-cmp-bibtex.discovery')
+local registry = require('blink-cmp-bibtex.registry')
 local matchers = require('blink-cmp-bibtex.matchers')
 
 local M = {}
@@ -102,11 +103,61 @@ local function merge_tables(base, override)
   return result
 end
 
+--- How each option that must not be a scalar is repaired when it is one
+--- 'registry' options accept true (the shipped entries) and false (none of
+--- them) as shorthands; every other option only ever holds a table, except the
+--- path options, which have always accepted a string or a function as well.
+--- @type table<string, string>
+local option_kinds = {
+  matchers = 'registry',
+  discovery = 'registry',
+  local_bib = 'map',
+  filetypes = 'list',
+  citation_commands = 'list',
+  root_markers = 'list',
+  files = 'path',
+  global_files = 'path',
+  search_paths = 'path',
+}
+
+--- Replace option values of a type the plugin cannot use
+--- Everything downstream indexes these values, iterates them or takes their
+--- length, so a scalar left in place would crash a completion round, the
+--- scanner or the health check. Repairing them here means each consumer can
+--- keep reading the option directly, and the user is told once what happened.
+--- @param resolved table The merged options, modified in place
+--- @return table The same table
+local function sanitize(resolved)
+  for name, kind in pairs(option_kinds) do
+    local value = resolved[name]
+    local usable = type(value) == 'table'
+      or (kind == 'path' and (type(value) == 'string' or type(value) == 'function'))
+      -- Only false passes through, disabling the registry; true means "what the
+      -- plugin ships" and is expanded into the default below.
+      or (kind == 'registry' and value == false)
+
+    if not usable and value ~= nil then
+      if kind == 'registry' and value == true then
+        -- Reads as "use what the plugin ships", which is what the default is.
+        resolved[name] = deep_copy(defaults[name])
+      else
+        registry.warn_once(
+          'config',
+          name,
+          string.format("option '%s' is %s, which cannot be used; the default applies", name, type(value))
+        )
+        resolved[name] = deep_copy(defaults[name])
+      end
+    end
+  end
+  return resolved
+end
+
 --- Setup configuration with custom options
 --- @param opts table|nil User-provided configuration options
 --- @return table The final merged configuration
 function M.setup(opts)
-  options = merge_tables(defaults, opts)
+  options = sanitize(merge_tables(defaults, opts))
   return options
 end
 
@@ -114,7 +165,7 @@ end
 --- @param opts table|nil Additional options to merge
 --- @return table The extended configuration
 function M.extend(opts)
-  return merge_tables(options, opts)
+  return sanitize(merge_tables(options, opts))
 end
 
 --- Get the current configuration

--- a/lua/blink-cmp-bibtex/config.lua
+++ b/lua/blink-cmp-bibtex/config.lua
@@ -51,9 +51,11 @@ local defaults = {
   },
 }
 
---- Deep copy a table to avoid mutation
---- @param tbl table The table to copy
---- @return table A deep copy of the table
+--- Deep copy a value, so that callers cannot mutate what they were given
+--- Anything that is not a table is returned as-is, which is what lets the
+--- option repair below copy a default without knowing its shape.
+--- @param tbl any The value to copy
+--- @return any A deep copy, for a table, or the value itself
 local function deep_copy(tbl)
   if type(tbl) ~= 'table' then
     return tbl

--- a/lua/blink-cmp-bibtex/discovery.lua
+++ b/lua/blink-cmp-bibtex/discovery.lua
@@ -653,10 +653,17 @@ end
 --- @param opts table|nil Configuration options
 --- @return BibtexDiscoverySpec[] The hooks to run, in order
 function M.chain(filetype, opts)
-  if opts and opts.discovery == false then
+  local configured = opts and opts.discovery
+  if configured == false then
     return {}
   end
-  local configured = opts and opts.discovery or M.defaults
+  if configured ~= nil and configured ~= true and type(configured) ~= 'table' then
+    -- Unusable: reported once, then treated as though nothing was configured,
+    -- which for discovery means the shipped hooks.
+    registry.warn_once('discovery', 'option', string.format('discovery is %s, which cannot be used', type(configured)))
+    configured = nil
+  end
+  configured = (configured == true or configured == nil) and M.defaults or configured
   local shared = configured['*'] or {}
   local per_filetype = filetype and configured[filetype] or {}
 

--- a/lua/blink-cmp-bibtex/discovery.lua
+++ b/lua/blink-cmp-bibtex/discovery.lua
@@ -630,12 +630,19 @@ end
 --- Unlike matchers.chain, this falls back to the shipped defaults when no
 --- discovery is configured at all. find_bib_files_from_buffer is public and is
 --- called with no options, and buffer discovery has always worked in that case,
---- so an absent discovery key must not mean "discover nothing". Setting
---- discovery to an empty table is what turns discovery off.
+--- so an absent discovery key must not mean "discover nothing".
+---
+--- Turning discovery off is therefore explicit: `discovery = false`. An empty
+--- table means the same thing, but only when the options reach this module
+--- unmerged; setup() merges maps key by key, so an empty table configured there
+--- keeps the shipped hooks. `false` is not a table and survives the merge.
 --- @param filetype string|nil The buffer filetype
 --- @param opts table|nil Configuration options
 --- @return BibtexDiscoverySpec[] The hooks to run, in order
 function M.chain(filetype, opts)
+  if opts and opts.discovery == false then
+    return {}
+  end
   local configured = opts and opts.discovery or M.defaults
   local shared = configured['*'] or {}
   local per_filetype = filetype and configured[filetype] or {}

--- a/lua/blink-cmp-bibtex/discovery.lua
+++ b/lua/blink-cmp-bibtex/discovery.lua
@@ -565,7 +565,11 @@ function M.normalize(name, value, filetype)
   if value == true then
     find = M.builtin[name]
     if not find then
-      registry.warn_once(name, string.format("discovery hook '%s' is enabled but no built-in hook has that name", name))
+      registry.warn_once(
+        'discovery',
+        name,
+        string.format("discovery hook '%s' is enabled but no built-in hook has that name", name)
+      )
       return nil
     end
     inherited = shipped_spec(name, filetype)
@@ -574,14 +578,18 @@ function M.normalize(name, value, filetype)
   elseif type(value) == 'string' then
     find = M.builtin[value]
     if not find then
-      registry.warn_once(name, string.format("discovery hook '%s' refers to unknown built-in hook '%s'", name, value))
+      registry.warn_once(
+        'discovery',
+        name,
+        string.format("discovery hook '%s' refers to unknown built-in hook '%s'", name, value)
+      )
       return nil
     end
     inherited = shipped_spec(value, filetype)
   elseif type(value) == 'table' then
     local reason = malformed_field_reason(value)
     if reason then
-      registry.warn_once(name, string.format("discovery hook '%s' is skipped: %s", name, reason))
+      registry.warn_once('discovery', name, string.format("discovery hook '%s' is skipped: %s", name, reason))
       return nil
     end
     extra = value
@@ -591,6 +599,7 @@ function M.normalize(name, value, filetype)
       find = M.builtin[name]
       if not find then
         registry.warn_once(
+          'discovery',
           name,
           string.format("discovery hook '%s' has no find function and no built-in hook has that name", name)
         )
@@ -599,7 +608,11 @@ function M.normalize(name, value, filetype)
       inherited = shipped_spec(name, filetype)
     end
   else
-    registry.warn_once(name, string.format("discovery hook '%s' has unsupported type '%s'", name, type(value)))
+    registry.warn_once(
+      'discovery',
+      name,
+      string.format("discovery hook '%s' has unsupported type '%s'", name, type(value))
+    )
     return nil
   end
 
@@ -717,6 +730,7 @@ function M.collect(ctx)
       if problem then
         registry.mark_failed(spec.find, ctx.filetype)
         registry.warn_once(
+          'discovery',
           string.format('%s@%s', spec.name, ctx.filetype or registry.NO_FILETYPE),
           string.format(
             "discovery hook '%s' %s and is disabled for filetype '%s'",

--- a/lua/blink-cmp-bibtex/discovery.lua
+++ b/lua/blink-cmp-bibtex/discovery.lua
@@ -1,0 +1,730 @@
+--- Buffer bibliography discovery for blink-cmp-bibtex
+--- A discovery hook reads a buffer and reports the bibliography files it
+--- declares. The hooks shipped here understand LaTeX, Markdown YAML front
+--- matter, Typst and GAPDoc; users register their own through the discovery
+--- option. This module never requires the config module; it only receives opts.
+--- @module 'blink-cmp-bibtex.discovery'
+
+local path_util = require('blink-cmp-bibtex.path')
+local registry = require('blink-cmp-bibtex.registry')
+
+local M = {}
+
+--- What a discovery hook is given
+--- The lines table is shared between hooks and must be treated as read-only.
+--- @class BibtexDiscoveryContext
+--- @field bufnr number The buffer being scanned
+--- @field filetype string|nil The buffer filetype
+--- @field lines string[] The buffer lines, read-only
+--- @field bufname string|nil The buffer file name, empty for scratch buffers
+--- @field dir string|nil The buffer's directory, for resolving relative paths
+--- @field opts table Configuration options
+
+--- A discovery hook
+--- Unlike a matcher, a hook takes no subject argument: the lines it reads are
+--- already part of the context.
+--- @alias BibtexDiscoveryFn fun(ctx: BibtexDiscoveryContext): string[]|string|nil
+
+--- A normalized discovery entry
+--- @class BibtexDiscoverySpec
+--- @field name string The hook name
+--- @field find BibtexDiscoveryFn The hook itself
+--- @field priority number Lower runs first (default 50); affects output order only
+--- @field extension boolean|nil When not false, extensionless results get '.bib'
+
+--- Default priority for hooks that do not declare one
+--- @type number
+local DEFAULT_PRIORITY = 50
+
+--- BibTeX bibliography command names to recognize
+--- @type table<string, boolean>
+local bibliography_commands = {
+  addbibresource = true,
+  ['addbibresource*'] = true,
+  addglobalbib = true,
+  addsectionbib = true,
+  bibliography = true,
+  nobibliography = true,
+}
+
+--- Trim whitespace from a string
+--- @param value string The string to trim
+--- @return string The trimmed string
+local function trim(value)
+  return value:match('^%s*(.-)%s*$') or ''
+end
+
+--- Split a comma-separated resource string into individual entries
+--- @param value string The resource string to split
+--- @return string[] List of resource names
+local function split_resources(value)
+  local entries = {}
+  for part in value:gmatch('[^,]+') do
+    local cleaned = trim(part)
+    if cleaned ~= '' then
+      entries[#entries + 1] = cleaned
+    end
+  end
+  if #entries == 0 and value ~= '' then
+    entries[1] = trim(value)
+  end
+  return entries
+end
+
+--- Skip whitespace in a string starting from a given index
+--- @param str string The input string
+--- @param idx number Starting index
+--- @return number The next non-whitespace index
+local function skip_whitespace(str, idx)
+  while idx <= #str and str:sub(idx, idx):match('%s') do
+    idx = idx + 1
+  end
+  return idx
+end
+
+--- Read a balanced block (e.g., braces) from a string
+--- @param str string The input string
+--- @param idx number Starting index
+--- @return string|nil, number The extracted block and next index
+local function read_balanced_block(str, idx)
+  if str:sub(idx, idx) ~= '{' then
+    return nil, idx
+  end
+  local depth = 1
+  local cursor = idx + 1
+  while cursor <= #str and depth > 0 do
+    local ch = str:sub(cursor, cursor)
+    if ch == '{' then
+      depth = depth + 1
+    elseif ch == '}' then
+      depth = depth - 1
+      if depth == 0 then
+        return str:sub(idx + 1, cursor - 1), cursor + 1
+      end
+    elseif ch == '\\' and cursor < #str then
+      cursor = cursor + 1
+    end
+    cursor = cursor + 1
+  end
+  return nil, idx
+end
+
+--- Skip optional arguments in a LaTeX command
+--- @param str string The input string
+--- @param idx number Starting index
+--- @return number The index after all optional arguments
+local function skip_optional_arguments(str, idx)
+  local cursor = skip_whitespace(str, idx)
+  while str:sub(cursor, cursor) == '[' do
+    local depth = 1
+    cursor = cursor + 1
+    while cursor <= #str and depth > 0 do
+      local ch = str:sub(cursor, cursor)
+      if ch == '[' then
+        depth = depth + 1
+      elseif ch == ']' then
+        depth = depth - 1
+      end
+      cursor = cursor + 1
+    end
+    cursor = skip_whitespace(str, cursor)
+  end
+  return cursor
+end
+
+--- Extract bibliography file paths from a LaTeX command line
+--- @param line string The line to parse
+--- @return string[] List of extracted file paths
+local function extract_command_paths(line)
+  local results = {}
+  local i = 1
+  while i <= #line do
+    local start_pos, end_pos, command = line:find('\\([%a%@]+%*?)', i)
+    if not start_pos then
+      break
+    end
+    i = end_pos + 1
+    if not bibliography_commands[command] then
+      goto continue
+    end
+    local cursor = skip_optional_arguments(line, i)
+    cursor = skip_whitespace(line, cursor)
+    local value
+    value, i = read_balanced_block(line, cursor)
+    if value and #value > 0 then
+      local resources = split_resources(value)
+      for _, resource in ipairs(resources) do
+        results[#results + 1] = resource
+      end
+    end
+    ::continue::
+  end
+  return results
+end
+
+--- Find bibliography files in YAML front matter
+--- @param lines string[] Buffer lines to search
+--- @return string[] List of bibliography file paths
+local function find_yaml_bibliography(lines)
+  local resources = {}
+  local in_front_matter = false
+  local collecting_list = false
+  for idx, line in ipairs(lines) do
+    if idx == 1 and line:match('^%-%-%-%s*$') then
+      in_front_matter = true
+    elseif in_front_matter and line:match('^%-%-%-%s*$') then
+      break
+    elseif in_front_matter then
+      local inline = line:match('^bibliography:%s*(.+)$')
+      if inline then
+        resources[#resources + 1] = trim(inline)
+        collecting_list = false
+      elseif line:match('^bibliography:%s*$') then
+        collecting_list = true
+      elseif line:match('^%S') and not line:match('^%s') then
+        collecting_list = false
+      end
+      if collecting_list then
+        local list_item = line:match('^%s*%-%s*(.+)%s*$')
+        if list_item then
+          resources[#resources + 1] = trim(list_item)
+        end
+      end
+    end
+  end
+  return resources
+end
+
+--- Find Typst import statements
+--- @param lines string[] Buffer lines to search
+--- @return string[] List of imported file paths
+local function find_typst_imports(lines)
+  local imports = {}
+  for _, line in ipairs(lines) do
+    -- Match #import patterns with double quotes:
+    -- #import "file.typ"
+    -- #import "file.typ": item
+    -- #import "file.typ": *
+    -- Capture the path within double quotes
+    for path in line:gmatch('#import%s+"([^"]+)"') do
+      if path:match('%.typ$') then
+        imports[#imports + 1] = trim(path)
+      end
+    end
+    -- Match #import patterns with single quotes:
+    -- #import 'file.typ'
+    -- #import 'file.typ': item
+    -- #import 'file.typ': *
+    -- Capture the path within single quotes
+    for path in line:gmatch("#import%s+'([^']+)'") do
+      if path:match('%.typ$') then
+        imports[#imports + 1] = trim(path)
+      end
+    end
+  end
+  return imports
+end
+
+--- Read lines from a file
+--- @param filepath string The file path to read
+--- @return string[]|nil List of lines or nil if file cannot be read
+local function read_file_lines(filepath)
+  local fd = io.open(filepath, 'r')
+  if not fd then
+    -- Silently return nil for missing imports - this is expected in many cases
+    -- as users may import files that don't exist yet or are in different locations
+    return nil
+  end
+  local lines = {}
+  for line in fd:lines() do
+    lines[#lines + 1] = line
+  end
+  fd:close()
+  return lines
+end
+
+--- Find bibliography files in Typst #bibliography() declarations
+--- Recursively follows #import statements to find bibliographies in imported files
+--- @param lines string[] Buffer lines to search
+--- @param base_dir string|nil Directory to resolve relative imports from
+--- @param visited table<string, boolean>|nil Table to track visited files (prevents cycles)
+--- @return string[] List of bibliography file paths
+local function find_typst_bibliography(lines, base_dir, visited)
+  visited = visited or {}
+  local resources = {}
+
+  -- Find direct bibliography declarations
+  for _, line in ipairs(lines) do
+    -- Match #bibliography("path/to/file.bib") with double quotes
+    for path in line:gmatch('#bibliography%s*%(%s*"([^"]+)"%s*%)') do
+      path = trim(path)
+      if not path_util.is_absolute(path) and base_dir then
+        path = path_util.joinpath(base_dir, path) --[[@as string]]
+      end
+      resources[#resources + 1] = path
+    end
+    -- Match #bibliography('path/to/file.bib') with single quotes
+    for path in line:gmatch("#bibliography%s*%(%s*'([^']+)'%s*%)") do
+      path = trim(path)
+      if not path_util.is_absolute(path) and base_dir then
+        path = path_util.joinpath(base_dir, path) --[[@as string]]
+      end
+      resources[#resources + 1] = path
+    end
+  end
+
+  -- Follow imports to find bibliographies in imported files
+  if base_dir then
+    local imports = find_typst_imports(lines)
+    for _, import_path in ipairs(imports) do
+      local full_path
+      if path_util.is_absolute(import_path) then
+        full_path = path_util.normalize(import_path)
+      else
+        full_path = path_util.normalize(path_util.joinpath(base_dir, import_path))
+      end
+
+      if full_path and not visited[full_path] then
+        visited[full_path] = true
+        local import_lines = read_file_lines(full_path)
+        if import_lines then
+          local import_dir = vim.fs.dirname(full_path)
+          local imported_resources = find_typst_bibliography(import_lines, import_dir, visited)
+          for _, resource in ipairs(imported_resources) do
+            -- Resolve imported resource paths relative to the imported file's directory
+            if not path_util.is_absolute(resource) then
+              resource = path_util.joinpath(import_dir, resource) --[[@as string]]
+            end
+            resources[#resources + 1] = resource
+          end
+        end
+      end
+    end
+  end
+
+  return resources
+end
+
+--- Find bibliography databases in GAPDoc <Bibliography Databases="..."/> declarations
+--- Per the GAPDoc DTD the element is EMPTY with a required Databases attribute
+--- and an optional Style attribute; several databases are separated by commas.
+--- BibTeX databases are named without their .bib extension, while BibXMLext
+--- databases carry their full .xml name and are skipped here, since this plugin
+--- reads BibTeX and Hayagriva rather than BibXMLext.
+--- The opening of a GAPDoc bibliography declaration
+--- @type string
+local BIBLIOGRAPHY_TAG = '<Bibliography'
+
+--- Blank out the XML regions whose contents are not live markup
+--- Comments, CDATA sections and processing instructions all hold text that an
+--- XML processor never reads as markup, so a declaration inside one names a
+--- bibliography that is not in use. An unterminated opener runs to the end of
+--- the document, which is what an editor shows while such a region is being
+--- typed. Regions are replaced by a space rather than removed so that the
+--- markup around them cannot be glued together.
+--- @param text string The document text
+--- @return string The text with inactive regions blanked out
+local function strip_inactive_regions(text)
+  text = text:gsub('<!%-%-.-%-%->', ' ')
+  text = text:gsub('<!%[CDATA%[.-%]%]>', ' ')
+  text = text:gsub('<%?.-%?>', ' ')
+  -- A DOCTYPE may carry an internal subset, whose entity declarations hold
+  -- replacement text that is not markup until an entity is referenced. The
+  -- '[^>%[]*' guard keeps this from reaching past the DOCTYPE's own '>' into a
+  -- later element that happens to contain brackets.
+  text = text:gsub('<!DOCTYPE[^>%[]*%[.-%]%s*>', ' ')
+  text = text:gsub('<!DOCTYPE[^>]*>', ' ')
+  text = text:gsub('<!%-%-.*$', ' ')
+  text = text:gsub('<!%[CDATA%[.*$', ' ')
+  text = text:gsub('<%?.*$', ' ')
+  text = text:gsub('<!DOCTYPE.*$', ' ')
+  return text
+end
+
+--- The character references XML predefines, which need no DTD declaration
+--- @type table<string, string>
+local xml_entities = {
+  amp = '&',
+  lt = '<',
+  gt = '>',
+  quot = '"',
+  apos = "'",
+}
+
+--- Resolve one XML character reference to the character it stands for
+--- @param reference string The reference body, without the '&' and ';'
+--- @return string|nil The character, or nil when the reference is not resolvable
+local function resolve_xml_reference(reference)
+  local code = tonumber(reference:match('^#[xX](%x+)$') or '', 16) or tonumber(reference:match('^#(%d+)$') or '')
+  if code then
+    if code < 1 or code > 0x10FFFF then
+      return nil
+    end
+    return vim.fn.nr2char(code, 1)
+  end
+  -- Entity names are case sensitive in XML, so they are looked up as written.
+  return xml_entities[reference]
+end
+
+--- Decode the XML character references in an attribute value
+--- An XML processor resolves these before GAPDoc ever sees the value, so this
+--- runs before the value is split on commas. References that are not the five
+--- predefined entities or a numeric escape are left as written.
+--- @param value string The raw attribute value
+--- @return string The decoded value
+local function decode_xml_references(value)
+  return (value:gsub('&(#?%w+);', resolve_xml_reference))
+end
+
+--- Read the Databases attribute of a single <Bibliography> element
+--- @param element string The element text, from '<Bibliography' to its '>'
+--- @return string|nil The attribute value, or nil when the element has none
+local function read_databases_attribute(element)
+  return element:match('Databases%s*=%s*"([^"]*)"') or element:match("Databases%s*=%s*'([^']*)'")
+end
+
+--- @param lines string[] Buffer lines to search
+--- @return string[] File names as written in the Databases attribute with '.bib'
+---   appended; entries may carry a directory part and may contain dots
+local function find_gapdoc_bibliography(lines)
+  -- Every buffer is scanned regardless of filetype, so the cost of joining the
+  -- lines is only paid once a declaration can actually be present.
+  local marked = false
+  for _, line in ipairs(lines) do
+    if line:find(BIBLIOGRAPHY_TAG, 1, true) then
+      marked = true
+      break
+    end
+  end
+  if not marked then
+    return {}
+  end
+
+  -- Joined so that a declaration split across lines is still found.
+  local text = strip_inactive_regions(table.concat(lines, '\n'))
+
+  local resources = {}
+  -- One pass in source order, reading both attribute quote styles as they come,
+  -- so that the returned list follows the document rather than the quoting.
+  local cursor = 1
+  while true do
+    local start_pos = text:find(BIBLIOGRAPHY_TAG .. '%s', cursor)
+    if not start_pos then
+      break
+    end
+    local rest = text:sub(start_pos)
+    -- Bounded by the element's own '>', so a Databases attribute belonging to a
+    -- later element is never read. The second form covers an element still
+    -- being typed at the end of the document, where no '>' exists yet.
+    local element = rest:match('^<Bibliography%s[^>]*>') or rest:match('^<Bibliography%s[^>]*$')
+    local databases = element and read_databases_attribute(element)
+    databases = databases and decode_xml_references(databases)
+    for _, name in ipairs(databases and split_resources(databases) or {}) do
+      -- BibXMLext databases carry their full .xml name and are skipped; every
+      -- other name is a BibTeX database, which the DTD defines as being
+      -- written without its .bib extension, so it is always appended.
+      if not name:lower():match('%.xml$') then
+        resources[#resources + 1] = name .. '.bib'
+      end
+    end
+    cursor = start_pos + #BIBLIOGRAPHY_TAG
+  end
+  return resources
+end
+
+--- Ensure a path has a bibliography extension (.bib, .yml, or .yaml)
+--- @param path string|nil The path to check
+--- @return string|nil The path with .bib extension if needed (unless it already has .yml or .yaml)
+local function ensure_bib_extension(path)
+  if not path or path == '' then
+    return path
+  end
+  if path:find('[%*%?%[]') then
+    return path
+  end
+  -- Accept .bib, .yml, .yaml extensions as-is
+  if path:match('%.bib$') or path:match('%.ya?ml$') then
+    return path
+  end
+  local filename = path:match('([^/\\]+)$') or path
+  if filename:find('%.') then
+    return path
+  end
+  return path .. '.bib'
+end
+
+--- Find the bibliographies a LaTeX buffer declares
+--- @param ctx BibtexDiscoveryContext
+--- @return string[]
+function M.latex(ctx)
+  local resources = {}
+  for _, line in ipairs(ctx.lines) do
+    for _, resource in ipairs(extract_command_paths(line)) do
+      resources[#resources + 1] = resource
+    end
+  end
+  return resources
+end
+
+--- Find the bibliographies declared in Markdown YAML front matter
+--- @param ctx BibtexDiscoveryContext
+--- @return string[]
+function M.yaml(ctx)
+  return find_yaml_bibliography(ctx.lines)
+end
+
+--- Find the bibliographies a Typst buffer declares, following its imports
+--- @param ctx BibtexDiscoveryContext
+--- @return string[]
+function M.typst(ctx)
+  return find_typst_bibliography(ctx.lines, ctx.dir)
+end
+
+--- Find the bibliographies a GAPDoc document declares
+--- @param ctx BibtexDiscoveryContext
+--- @return string[]
+function M.gapdoc(ctx)
+  return find_gapdoc_bibliography(ctx.lines)
+end
+
+--- Hooks shipped with the plugin, addressable by name from the configuration
+--- @type table<string, BibtexDiscoveryFn>
+M.builtin = {
+  latex = M.latex,
+  yaml = M.yaml,
+  typst = M.typst,
+  gapdoc = M.gapdoc,
+}
+
+--- The discovery shipped with the plugin, and the source of the config default
+--- Every hook sits under '*' because buffer discovery is filetype agnostic: an
+--- \addbibresource in a Markdown buffer is found today, and narrowing the hooks
+--- per filetype would silently stop finding it. This is the opposite of
+--- matchers.defaults, where the filetype decides which syntax applies.
+--- The priorities reproduce the order the extractors ran in before they became
+--- hooks.
+--- @type table<string, table<string, table>>
+M.defaults = {
+  ['*'] = {
+    latex = { priority = 10 },
+    yaml = { priority = 20 },
+    typst = { priority = 30 },
+    -- Appends '.bib' itself, because GAPDoc names are extensionless by
+    -- definition and the generic rule would misread a dotted name.
+    gapdoc = { priority = 40, extension = false },
+  },
+}
+
+--- The spec fields shipped for a built-in hook in a filetype context
+--- @param name string The built-in hook name
+--- @param filetype string|nil The filetype whose chain is being built
+--- @return table|nil The shipped entry, or nil when nothing is shipped
+local function shipped_spec(name, filetype)
+  local per_filetype = filetype and M.defaults[filetype]
+  local entry = per_filetype and per_filetype[name]
+  if type(entry) ~= 'table' then
+    entry = M.defaults['*'] and M.defaults['*'][name]
+  end
+  return type(entry) == 'table' and entry or nil
+end
+
+--- Describe the first unusable optional field of a configured spec table
+--- @param spec table The user's spec table
+--- @return string|nil A reason, or nil when every optional field is well formed
+local function malformed_field_reason(spec)
+  if spec.priority ~= nil and type(spec.priority) ~= 'number' then
+    return string.format('priority is %s instead of a number', type(spec.priority))
+  end
+  if spec.extension ~= nil and type(spec.extension) ~= 'boolean' then
+    return string.format('extension is %s instead of a boolean', type(spec.extension))
+  end
+  return nil
+end
+
+--- Normalize a configured discovery value into a spec
+--- Accepts the same forms as a matcher: false or nil to disable, true for the
+--- built-in of the same name, a built-in name, a function, or a spec table.
+--- Invalid values are skipped with a single warning per name.
+---
+--- Whenever the hook comes from a built-in, the fields left out are inherited
+--- in this order, so re-enabling one with true keeps what it ships with:
+---   1. the field spelled out in the user's own spec table
+---   2. the field this filetype ships for that built-in in M.defaults
+---   3. the field '*' ships for that built-in in M.defaults
+---   4. DEFAULT_PRIORITY for priority, nil for the rest
+--- @param name string The configuration key the value was found under
+--- @param value any The configured value
+--- @param filetype string|nil The filetype whose chain is being built
+--- @return BibtexDiscoverySpec|nil The normalized spec, or nil when disabled or invalid
+function M.normalize(name, value, filetype)
+  if value == nil or value == false then
+    return nil
+  end
+
+  local find, extra, inherited
+  if value == true then
+    find = M.builtin[name]
+    if not find then
+      registry.warn_once(name, string.format("discovery hook '%s' is enabled but no built-in hook has that name", name))
+      return nil
+    end
+    inherited = shipped_spec(name, filetype)
+  elseif type(value) == 'function' then
+    find = value
+  elseif type(value) == 'string' then
+    find = M.builtin[value]
+    if not find then
+      registry.warn_once(name, string.format("discovery hook '%s' refers to unknown built-in hook '%s'", name, value))
+      return nil
+    end
+    inherited = shipped_spec(value, filetype)
+  elseif type(value) == 'table' then
+    local reason = malformed_field_reason(value)
+    if reason then
+      registry.warn_once(name, string.format("discovery hook '%s' is skipped: %s", name, reason))
+      return nil
+    end
+    extra = value
+    if type(value.find) == 'function' then
+      find = value.find
+    else
+      find = M.builtin[name]
+      if not find then
+        registry.warn_once(
+          name,
+          string.format("discovery hook '%s' has no find function and no built-in hook has that name", name)
+        )
+        return nil
+      end
+      inherited = shipped_spec(name, filetype)
+    end
+  else
+    registry.warn_once(name, string.format("discovery hook '%s' has unsupported type '%s'", name, type(value)))
+    return nil
+  end
+
+  --- Read a spec field, preferring the user's own value over the shipped one
+  --- @param field_name string The spec field to read
+  --- @return any
+  local function field(field_name)
+    if extra and extra[field_name] ~= nil then
+      return extra[field_name]
+    end
+    if inherited and inherited[field_name] ~= nil then
+      return inherited[field_name]
+    end
+    return nil
+  end
+
+  return {
+    name = name,
+    find = find,
+    priority = field('priority') or DEFAULT_PRIORITY,
+    extension = field('extension'),
+  }
+end
+
+--- Build the ordered hook chain for a filetype
+--- Entries under the filetype key override same-named '*' entries.
+---
+--- Unlike matchers.chain, this falls back to the shipped defaults when no
+--- discovery is configured at all. find_bib_files_from_buffer is public and is
+--- called with no options, and buffer discovery has always worked in that case,
+--- so an absent discovery key must not mean "discover nothing". Setting
+--- discovery to an empty table is what turns discovery off.
+--- @param filetype string|nil The buffer filetype
+--- @param opts table|nil Configuration options
+--- @return BibtexDiscoverySpec[] The hooks to run, in order
+function M.chain(filetype, opts)
+  local configured = opts and opts.discovery or M.defaults
+  local shared = configured['*'] or {}
+  local per_filetype = filetype and configured[filetype] or {}
+
+  local values = {}
+  for name, value in pairs(shared) do
+    values[name] = value
+  end
+  for name, value in pairs(per_filetype) do
+    values[name] = value
+  end
+
+  local specs = {}
+  for name, value in pairs(values) do
+    local spec = M.normalize(name, value, filetype)
+    if spec then
+      specs[#specs + 1] = spec
+    end
+  end
+
+  table.sort(specs, function(a, b)
+    if a.priority ~= b.priority then
+      return a.priority < b.priority
+    end
+    return a.name < b.name
+  end)
+  return specs
+end
+
+--- Describe why a hook result is unusable, if it is
+--- @param result any The value a hook returned
+--- @return string|nil A reason, or nil when the result is well formed
+local function malformed_result_reason(result)
+  if type(result) == 'string' then
+    return nil
+  end
+  if type(result) ~= 'table' then
+    return string.format('returned %s instead of a list of file names', type(result))
+  end
+  for _, entry in ipairs(result) do
+    if type(entry) ~= 'string' then
+      return string.format('returned a list holding %s instead of a file name', type(entry))
+    end
+  end
+  return nil
+end
+
+--- Run the hook chain and collect the file names it reports
+--- Results are concatenated in chain order and left unresolved; the caller
+--- resolves and deduplicates them.
+--- @param ctx BibtexDiscoveryContext
+--- @return string[] File names, in chain order
+function M.collect(ctx)
+  local resources = {}
+  for _, spec in ipairs(M.chain(ctx.filetype, ctx.opts)) do
+    if not registry.has_failed(spec.find, ctx.filetype) then
+      local ok, result = pcall(spec.find, ctx)
+      local problem
+      if not ok then
+        problem = string.format('raised an error: %s', registry.describe_error(result))
+      elseif result ~= nil and result ~= false then
+        problem = malformed_result_reason(result)
+      end
+      if problem then
+        registry.mark_failed(spec.find, ctx.filetype)
+        registry.warn_once(
+          string.format('%s@%s', spec.name, ctx.filetype or registry.NO_FILETYPE),
+          string.format(
+            "discovery hook '%s' %s and is disabled for filetype '%s'",
+            spec.name,
+            problem,
+            ctx.filetype or 'unset'
+          )
+        )
+      elseif result then
+        local found = type(result) == 'string' and { result } or result
+        for _, name in ipairs(found) do
+          resources[#resources + 1] = spec.extension == false and name or ensure_bib_extension(name)
+        end
+      end
+    end
+  end
+  return resources
+end
+
+--- Internal helpers exposed for testing. Not part of the public API.
+M.__test = {
+  --- Forget the per-session warning and failed-hook state.
+  reset = registry.reset,
+}
+
+return M

--- a/lua/blink-cmp-bibtex/discovery.lua
+++ b/lua/blink-cmp-bibtex/discovery.lua
@@ -697,6 +697,14 @@ end
 --- @return string[] File names, in chain order
 function M.collect(ctx)
   local resources = {}
+
+  --- Record one reported name, applying the hook's extension rule
+  --- @param spec BibtexDiscoverySpec The hook that reported it
+  --- @param name string The file name reported
+  local function remember(spec, name)
+    resources[#resources + 1] = spec.extension == false and name or ensure_bib_extension(name)
+  end
+
   for _, spec in ipairs(M.chain(ctx.filetype, ctx.opts)) do
     if not registry.has_failed(spec.find, ctx.filetype) then
       local ok, result = pcall(spec.find, ctx)
@@ -717,10 +725,11 @@ function M.collect(ctx)
             ctx.filetype or 'unset'
           )
         )
+      elseif type(result) == 'string' then
+        remember(spec, result)
       elseif result then
-        local found = type(result) == 'string' and { result } or result
-        for _, name in ipairs(found) do
-          resources[#resources + 1] = spec.extension == false and name or ensure_bib_extension(name)
+        for _, name in ipairs(result) do
+          remember(spec, name)
         end
       end
     end

--- a/lua/blink-cmp-bibtex/discovery.lua
+++ b/lua/blink-cmp-bibtex/discovery.lua
@@ -663,7 +663,9 @@ function M.chain(filetype, opts)
     registry.warn_once('discovery', 'option', string.format('discovery is %s, which cannot be used', type(configured)))
     configured = nil
   end
-  configured = (configured == true or configured == nil) and M.defaults or configured
+  if configured == nil or configured == true then
+    configured = M.defaults
+  end
   local shared = configured['*'] or {}
   local per_filetype = filetype and configured[filetype] or {}
 

--- a/lua/blink-cmp-bibtex/health.lua
+++ b/lua/blink-cmp-bibtex/health.lua
@@ -3,13 +3,16 @@
 --- @module 'blink-cmp-bibtex.health'
 
 local config = require('blink-cmp-bibtex.config')
+local discovery = require('blink-cmp-bibtex.discovery')
 local matchers = require('blink-cmp-bibtex.matchers')
 local scan = require('blink-cmp-bibtex.scan')
 
 local M = {}
 
---- Describe a matcher chain as a readable string
---- @param chain BibtexMatcherSpec[]
+--- Describe a chain as a readable string
+--- Reads only the name and priority every chain entry carries, so it serves the
+--- matcher chain and the discovery chain alike.
+--- @param chain table[] A matcher or discovery chain
 --- @return string
 local function describe_chain(chain)
   if #chain == 0 then
@@ -53,44 +56,85 @@ function M.check()
   h_info(string.format('files: %d configured', #scan.resolve_option_list(opts.files, bufnr)))
   h_info(string.format('global_files: %d configured', #scan.resolve_option_list(opts.global_files, bufnr)))
 
-  h_start('blink-cmp-bibtex: matchers')
+  --- Report one configurable chain, filetype by filetype
+  --- @param section string The section heading
+  --- @param configured table The chains as configured
+  --- @param chain_for fun(filetype: string|nil): table[] Builds the chain
+  --- @param shipped table The chains the plugin ships
+  --- @param empty_message string Reported when nothing at all is configured
+  --- @param consequence string What a dormant filetype key means for the user
+  local function report_section(section, configured, chain_for, shipped, empty_message, consequence)
+    h_start('blink-cmp-bibtex: ' .. section)
 
-  local configured = opts.matchers or {}
-  if vim.tbl_isempty(configured) then
-    h_warn('no matchers are configured — no completions will ever be offered')
-    return
-  end
+    if vim.tbl_isempty(configured) then
+      h_warn(empty_message)
+      return
+    end
 
-  h_info('shared ({"*"}): ' .. describe_chain(matchers.chain(nil, opts)))
+    h_info('shared ({"*"}): ' .. describe_chain(chain_for(nil)))
 
-  local names = {}
-  for name in pairs(configured) do
-    if name ~= '*' then
-      names[#names + 1] = name
+    local names = {}
+    for name in pairs(configured) do
+      if name ~= '*' then
+        names[#names + 1] = name
+      end
+    end
+    table.sort(names)
+
+    for _, filetype in ipairs(names) do
+      local chain = describe_chain(chain_for(filetype))
+      if #filetypes == 0 or vim.tbl_contains(filetypes, filetype) then
+        h_ok(string.format('%s: %s', filetype, chain))
+      elseif shipped[filetype] ~= nil then
+        -- Shipped with the plugin and dormant by design; not a misconfiguration.
+        h_info(string.format("%s: %s (dormant, '%s' is not in filetypes)", filetype, chain, filetype))
+      else
+        h_warn(
+          string.format(
+            "%s for '%s' are configured but '%s' is not in filetypes — %s",
+            section,
+            filetype,
+            filetype,
+            consequence
+          ),
+          { string.format("add '%s' to the filetypes option to enable it", filetype) }
+        )
+      end
     end
   end
-  table.sort(names)
 
-  local shipped = config.defaults().matchers or {}
+  local defaults = config.defaults()
 
-  for _, filetype in ipairs(names) do
-    local chain = describe_chain(matchers.chain(filetype, opts))
-    if #filetypes == 0 or vim.tbl_contains(filetypes, filetype) then
-      h_ok(string.format('%s: %s', filetype, chain))
-    elseif shipped[filetype] ~= nil then
-      -- Shipped with the plugin and dormant by design; not a misconfiguration.
-      h_info(string.format("%s: %s (dormant, '%s' is not in filetypes)", filetype, chain, filetype))
-    else
-      h_warn(
-        string.format(
-          "matchers for '%s' are configured but '%s' is not in filetypes — completions will not fire there",
-          filetype,
-          filetype
-        ),
-        { string.format("add '%s' to the filetypes option to enable it", filetype) }
-      )
-    end
+  report_section(
+    'matchers',
+    opts.matchers or {},
+    function(filetype)
+      return matchers.chain(filetype, opts)
+    end,
+    defaults.matchers or {},
+    'no matchers are configured — no completions will ever be offered',
+    'completions will not fire there'
+  )
+
+  -- Absent means the shipped hooks are in force; false, or anything else that
+  -- is not a table, means discovery is off.
+  local discovery_configured = opts.discovery
+  if discovery_configured == nil then
+    discovery_configured = defaults.discovery or {}
+  elseif type(discovery_configured) ~= 'table' then
+    discovery_configured = {}
   end
+
+  report_section(
+    'discovery',
+    discovery_configured,
+    function(filetype)
+      return discovery.chain(filetype, opts)
+    end,
+    defaults.discovery or {},
+    'buffer discovery is disabled — only files, global_files and search_paths will be used',
+    'bibliographies will not be discovered there'
+  )
 end
 
 return M

--- a/lua/blink-cmp-bibtex/health.lua
+++ b/lua/blink-cmp-bibtex/health.lua
@@ -44,13 +44,13 @@ function M.check()
 
   h_start('blink-cmp-bibtex')
 
-  local filetypes = opts.filetypes or {}
+  local filetypes = type(opts.filetypes) == 'table' and opts.filetypes or {}
   if #filetypes == 0 then
     h_info('filetypes: (empty) — the source is offered in every buffer')
   else
     h_ok('filetypes: ' .. table.concat(filetypes, ', '))
   end
-  h_info(string.format('preview_style: %s, max_entries: %d', opts.preview_style, opts.max_entries))
+  h_info(string.format('preview_style: %s, max_entries: %s', tostring(opts.preview_style), tostring(opts.max_entries)))
   -- files and global_files may be a list, a bare string, or a function, so they
   -- are resolved the same way the scanner resolves them before being counted.
   h_info(string.format('files: %d configured', #scan.resolve_option_list(opts.files, bufnr)))
@@ -66,7 +66,7 @@ function M.check()
   local function report_section(section, configured, chain_for, shipped, empty_message, consequence)
     h_start('blink-cmp-bibtex: ' .. section)
 
-    if vim.tbl_isempty(configured) then
+    if type(configured) ~= 'table' or vim.tbl_isempty(configured) then
       h_warn(empty_message)
       return
     end
@@ -107,7 +107,7 @@ function M.check()
 
   report_section(
     'matchers',
-    opts.matchers or {},
+    type(opts.matchers) == 'table' and opts.matchers or {},
     function(filetype)
       return matchers.chain(filetype, opts)
     end,
@@ -119,7 +119,7 @@ function M.check()
   -- Absent means the shipped hooks are in force; false, or anything else that
   -- is not a table, means discovery is off.
   local discovery_configured = opts.discovery
-  if discovery_configured == nil then
+  if discovery_configured == nil or discovery_configured == true then
     discovery_configured = defaults.discovery or {}
   elseif type(discovery_configured) ~= 'table' then
     discovery_configured = {}

--- a/lua/blink-cmp-bibtex/init.lua
+++ b/lua/blink-cmp-bibtex/init.lua
@@ -211,9 +211,16 @@ local function wants_sanitized_prefix(detection, spec)
   return wanted
 end
 
---- Characters a citation key may contain, used to find its end from the cursor
+--- Characters that end a citation key in one syntax or another
+--- The parser accepts any run of non-comma, non-whitespace characters as a key,
+--- so the cursor scan stops at delimiters rather than at an allowed alphabet:
+--- otherwise a key like smith/2020 or a+b would be cut at its punctuation.
 --- @type string
-local KEY_CHARACTER = '[%w:_%.%-]'
+local KEY_DELIMITERS = [[%s,;{}%[%]()<>"'\]]
+
+--- Matches one character a citation key may contain
+--- @type string
+local KEY_CHARACTER = '[^' .. KEY_DELIMITERS .. ']'
 
 --- Detect the citation key the cursor sits in or after
 --- The matchers read the text up to the cursor, while the cursor here may sit

--- a/lua/blink-cmp-bibtex/init.lua
+++ b/lua/blink-cmp-bibtex/init.lua
@@ -19,9 +19,24 @@ Source.__index = Source
 --- @field source_path string The file the entry was read from
 --- @field is_global boolean Whether source_path is one of the configured global files
 
---- Global lookup table for entry raw text, keyed by citation key
+--- Entry raw text from the most recent completion round, keyed by citation key
 --- @type table<string, BibEntryRef>
 local entry_lookup = {}
+
+--- The same table from the round before it
+--- Two generations are kept so that Source:execute still resolves an accepted
+--- item when a new round has already replaced the lookup, while the memory a
+--- session holds stays bounded by two rounds instead of growing with every key
+--- ever completed.
+--- @type table<string, BibEntryRef>
+local previous_entry_lookup = {}
+
+--- Look up a remembered entry, falling back to the previous round
+--- @param key string The citation key
+--- @return BibEntryRef|nil
+local function recall_entry(key)
+  return entry_lookup[key] or previous_entry_lookup[key]
+end
 
 --- Default completion kind (fallback to 1 if blink.cmp types unavailable)
 --- @type number
@@ -517,6 +532,9 @@ function Source:get_completions(context, callback)
     local items = {}
     local style = get_preview_style(self.opts.preview_style)
     local seen_keys = {}
+    -- Built fresh per round and swapped in below, so a round that is cancelled
+    -- or fails part way leaves the remembered entries untouched.
+    local round_lookup = {}
 
     for _, entry in ipairs(filtered) do
       -- Deduplicate: only process first occurrence (local preferred due to sort)
@@ -538,7 +556,7 @@ function Source:get_completions(context, callback)
 
         -- Store entry in lookup table for later use (e.g., copy to local bib)
         if entry.raw then
-          entry_lookup[entry.key] = {
+          round_lookup[entry.key] = {
             raw = entry.raw,
             source_path = entry.source_path,
             is_global = is_global,
@@ -559,6 +577,8 @@ function Source:get_completions(context, callback)
         }
       end
     end
+    previous_entry_lookup = entry_lookup
+    entry_lookup = round_lookup
     callback({ items = items, is_incomplete_forward = true, is_incomplete_backward = true })
   end)
   return function()
@@ -600,7 +620,7 @@ function Source:execute(context, item, callback, default_implementation)
   end
 
   -- Only auto-add if entry is from a global file
-  local entry_data = entry_lookup[key]
+  local entry_data = recall_entry(key)
   if entry_data and entry_data.is_global then
     local_bib.copy_entry(key, entry_data.raw, opts.local_bib)
   end
@@ -651,7 +671,7 @@ function Source.copy_to_local_bib(key)
 
   -- Look up the entry in our cache, validating source_path is current
   --- @type BibEntryRef|nil
-  local entry_data = entry_lookup[key]
+  local entry_data = recall_entry(key)
   if entry_data and entry_data.source_path then
     local normalized = vim.fs.normalize(entry_data.source_path)
     if not current_paths[normalized] then
@@ -686,7 +706,8 @@ function Source.copy_to_local_bib(key)
   return local_bib.copy_entry(key, entry_data.raw, opts.local_bib)
 end
 
---- Get the entry lookup table (for debugging/testing)
+--- Get the entry lookup table of the most recent completion round
+--- The previous round is retained separately and is not included here.
 --- @return table<string, BibEntryRef>
 function Source.get_entry_lookup()
   return entry_lookup

--- a/lua/blink-cmp-bibtex/init.lua
+++ b/lua/blink-cmp-bibtex/init.lua
@@ -195,6 +195,62 @@ local function sanitize_prefix(prefix)
   return trimmed:match('^@(.*)$') or trimmed
 end
 
+--- Whether a detected prefix should be reduced to the key being typed
+--- A match may opt out per match or per matcher; sanitizing is the default.
+--- @param detection BibtexMatchResult The match result
+--- @param spec BibtexMatcherSpec|nil The matcher that produced it
+--- @return boolean
+local function wants_sanitized_prefix(detection, spec)
+  local wanted = detection.sanitize
+  if wanted == nil then
+    wanted = spec and spec.sanitize
+  end
+  if wanted == nil then
+    wanted = true
+  end
+  return wanted
+end
+
+--- Characters a citation key may contain, used to find its end from the cursor
+--- @type string
+local KEY_CHARACTER = '[%w:_%.%-]'
+
+--- Detect the citation key the cursor sits in or after
+--- The matchers read the text up to the cursor, while the cursor here may sit
+--- anywhere inside a finished key, so the text is first extended to the end of
+--- that key. The chain runs for the buffer's filetype, which is what makes the
+--- GAPDoc and user-registered syntaxes work here and not just in completion.
+--- The original patterns remain as a fallback for text no matcher claims.
+--- @param bufnr number The buffer to read the filetype from
+--- @param opts table Configuration options
+--- @return string|nil The citation key, or nil when the cursor is not on one
+local function key_under_cursor(bufnr, opts)
+  local line = vim.api.nvim_get_current_line()
+  local col = vim.api.nvim_win_get_cursor(0)[2]
+  local finish = math.min(col + 1, #line)
+  while finish < #line and line:sub(finish + 1, finish + 1):match(KEY_CHARACTER) do
+    finish = finish + 1
+  end
+  local text = line:sub(1, finish)
+
+  local detection, spec = matchers.detect(text, opts, {
+    bufnr = bufnr,
+    filetype = vim.bo[bufnr].filetype,
+    line = line,
+    col = finish,
+  })
+  if detection then
+    local key = wants_sanitized_prefix(detection, spec) and sanitize_prefix(detection.prefix) or detection.prefix
+    if key and key ~= '' then
+      return key
+    end
+  end
+
+  return text:match('@(' .. KEY_CHARACTER .. '+)$')
+    or text:match('{(' .. KEY_CHARACTER .. '+)$')
+    or text:match(',(' .. KEY_CHARACTER .. '+)$')
+end
+
 --- Format author/editor list into a readable string
 --- @param fields table BibTeX entry fields
 --- @return string|nil Formatted author string or nil if not available
@@ -492,15 +548,8 @@ function Source:get_completions(context, callback)
     callback(empty_response())
     return function() end
   end
-  -- A match may opt out of prefix sanitization, either per match or per matcher.
-  local should_sanitize = detection.sanitize
-  if should_sanitize == nil then
-    should_sanitize = spec and spec.sanitize
-  end
-  if should_sanitize == nil then
-    should_sanitize = true
-  end
-  local prefix = should_sanitize and sanitize_prefix(detection.prefix) or (detection.prefix or '')
+  local prefix = wants_sanitized_prefix(detection, spec) and sanitize_prefix(detection.prefix)
+    or (detection.prefix or '')
   local paths = scan.resolve_bib_paths(bufnr, self.opts)
   if table_is_empty(paths) then
     callback(empty_response())
@@ -632,7 +681,11 @@ end
 Source.setup = config.setup
 
 --- Internal helpers exposed for testing. Not part of the public API.
-Source.__test = { extract_context = extract_context, sanitize_prefix = sanitize_prefix }
+Source.__test = {
+  extract_context = extract_context,
+  sanitize_prefix = sanitize_prefix,
+  key_under_cursor = key_under_cursor,
+}
 
 --- Copy a BibTeX entry to the local bib file
 --- @param key string|nil The citation key to copy (if nil, try to detect from cursor)
@@ -645,14 +698,11 @@ function Source.copy_to_local_bib(key)
     return false
   end
 
+  local bufnr = vim.api.nvim_get_current_buf()
+
   -- If no key provided, try to detect from cursor position
   if not key or key == '' then
-    local line = vim.api.nvim_get_current_line()
-    local col = vim.api.nvim_win_get_cursor(0)[2]
-    -- Try to extract citation key under/before cursor
-    local text = line:sub(1, col + 1)
-    -- Match citation key patterns (word chars, colon, underscore, dot, hyphen)
-    key = text:match('@([%w:_%.%-]+)$') or text:match('{([%w:_%.%-]+)$') or text:match(',([%w:_%.%-]+)$')
+    key = key_under_cursor(bufnr, opts)
     if not key then
       vim.notify('No citation key found at cursor', vim.log.levels.WARN, { title = 'blink-cmp-bibtex' })
       return false
@@ -660,7 +710,6 @@ function Source.copy_to_local_bib(key)
   end
 
   -- Get current bib paths for validation
-  local bufnr = vim.api.nvim_get_current_buf()
   local paths = scan.resolve_bib_paths(bufnr, opts)
 
   -- Build set of current paths for validation

--- a/lua/blink-cmp-bibtex/init.lua
+++ b/lua/blink-cmp-bibtex/init.lua
@@ -178,21 +178,45 @@ local function format_source_indicator(info)
   return ''
 end
 
+--- Characters that separate keys when a matcher does not say otherwise
+--- @type string
+local DEFAULT_SEPARATORS = ',;'
+
 --- Sanitize a citation key prefix by handling multi-key citations
---- Extracts the last citation key being typed when multiple keys are separated by commas or semicolons
+--- Extracts the last citation key being typed when several keys are listed.
+--- Which characters separate them depends on the syntax: LaTeX and Typst use a
+--- comma, while Pandoc also uses a semicolon. A semicolon is an ordinary
+--- character in a key otherwise, and the parser accepts it as one.
 --- @param prefix string|nil The raw prefix string
+--- @param separators string|nil Separator characters; defaults to a comma and a semicolon
 --- @return string The sanitized prefix for the current key
-local function sanitize_prefix(prefix)
+local function sanitize_prefix(prefix, separators)
   if not prefix or prefix == '' then
     return ''
   end
-  -- Normalize semicolons to commas and extract last segment
-  local normalized = prefix:gsub(';', ',')
-  local segments = vim.split(normalized, ',', { trimempty = false })
+  separators = separators or DEFAULT_SEPARATORS
+  if separators == '' then
+    separators = DEFAULT_SEPARATORS
+  end
+  -- Normalize every separator to the first one, then take the last segment
+  local primary = separators:sub(1, 1)
+  local normalized = prefix
+  for index = 2, #separators do
+    normalized = normalized:gsub('%' .. separators:sub(index, index), primary)
+  end
+  local segments = vim.split(normalized, primary, { plain = true, trimempty = false })
   local candidate = segments[#segments] or ''
   -- Trim whitespace and strip leading @ symbol (for multi-ref Pandoc citations)
   local trimmed = candidate:match('^%s*(.-)%s*$') or ''
   return trimmed:match('^@(.*)$') or trimmed
+end
+
+--- The key separators that apply to a match
+--- @param detection BibtexMatchResult The match result
+--- @param spec BibtexMatcherSpec|nil The matcher that produced it
+--- @return string
+local function separators_for(detection, spec)
+  return detection.separators or (spec and spec.separators) or DEFAULT_SEPARATORS
 end
 
 --- Whether a detected prefix should be reduced to the key being typed
@@ -216,7 +240,7 @@ end
 --- so the cursor scan stops at delimiters rather than at an allowed alphabet:
 --- otherwise a key like smith/2020 or a+b would be cut at its punctuation.
 --- @type string
-local KEY_DELIMITERS = [[%s,;{}%[%]()<>"'\]]
+local KEY_DELIMITERS = [[%s,{}%[%]()<>"'\]]
 
 --- Matches one character a citation key may contain
 --- @type string
@@ -238,7 +262,8 @@ local function key_under_cursor(bufnr, opts)
   while finish < #line and line:sub(finish + 1, finish + 1):match(KEY_CHARACTER) do
     finish = finish + 1
   end
-  local text = line:sub(1, finish)
+  -- A separator the scan swallowed belongs to the next key, not to this one.
+  local text = line:sub(1, finish):gsub('[,;]+$', '')
 
   local detection, spec = matchers.detect(text, opts, {
     bufnr = bufnr,
@@ -247,7 +272,10 @@ local function key_under_cursor(bufnr, opts)
     col = finish,
   })
   if detection then
-    local key = wants_sanitized_prefix(detection, spec) and sanitize_prefix(detection.prefix) or detection.prefix
+    local key = detection.prefix
+    if wants_sanitized_prefix(detection, spec) then
+      key = sanitize_prefix(detection.prefix, separators_for(detection, spec))
+    end
     if key and key ~= '' then
       return key
     end
@@ -555,8 +583,10 @@ function Source:get_completions(context, callback)
     callback(empty_response())
     return function() end
   end
-  local prefix = wants_sanitized_prefix(detection, spec) and sanitize_prefix(detection.prefix)
-    or (detection.prefix or '')
+  local prefix = detection.prefix or ''
+  if wants_sanitized_prefix(detection, spec) then
+    prefix = sanitize_prefix(detection.prefix, separators_for(detection, spec))
+  end
   local paths = scan.resolve_bib_paths(bufnr, self.opts)
   if table_is_empty(paths) then
     callback(empty_response())

--- a/lua/blink-cmp-bibtex/matchers.lua
+++ b/lua/blink-cmp-bibtex/matchers.lua
@@ -247,7 +247,11 @@ function M.normalize(name, value, filetype)
   if value == true then
     match = M.builtin[name]
     if not match then
-      registry.warn_once(name, string.format("matcher '%s' is enabled but no built-in matcher has that name", name))
+      registry.warn_once(
+        'matcher',
+        name,
+        string.format("matcher '%s' is enabled but no built-in matcher has that name", name)
+      )
       return nil
     end
     inherited = shipped_spec(name, filetype)
@@ -256,14 +260,18 @@ function M.normalize(name, value, filetype)
   elseif type(value) == 'string' then
     match = M.builtin[value]
     if not match then
-      registry.warn_once(name, string.format("matcher '%s' refers to unknown built-in matcher '%s'", name, value))
+      registry.warn_once(
+        'matcher',
+        name,
+        string.format("matcher '%s' refers to unknown built-in matcher '%s'", name, value)
+      )
       return nil
     end
     inherited = shipped_spec(value, filetype)
   elseif type(value) == 'table' then
     local reason = malformed_field_reason(value)
     if reason then
-      registry.warn_once(name, string.format("matcher '%s' is skipped: %s", name, reason))
+      registry.warn_once('matcher', name, string.format("matcher '%s' is skipped: %s", name, reason))
       return nil
     end
     extra = value
@@ -273,6 +281,7 @@ function M.normalize(name, value, filetype)
       match = M.builtin[name]
       if not match then
         registry.warn_once(
+          'matcher',
           name,
           string.format("matcher '%s' has no match function and no built-in matcher has that name", name)
         )
@@ -281,7 +290,7 @@ function M.normalize(name, value, filetype)
       inherited = shipped_spec(name, filetype)
     end
   else
-    registry.warn_once(name, string.format("matcher '%s' has unsupported type '%s'", name, type(value)))
+    registry.warn_once('matcher', name, string.format("matcher '%s' has unsupported type '%s'", name, type(value)))
     return nil
   end
 
@@ -364,6 +373,7 @@ function M.detect(text, opts, ctx)
       if problem then
         registry.mark_failed(spec.match, filetype)
         registry.warn_once(
+          'matcher',
           string.format('%s@%s', spec.name, filetype or registry.NO_FILETYPE),
           string.format("matcher '%s' %s and is disabled for filetype '%s'", spec.name, problem, filetype or 'unset')
         )

--- a/lua/blink-cmp-bibtex/matchers.lua
+++ b/lua/blink-cmp-bibtex/matchers.lua
@@ -4,6 +4,8 @@
 --- This module never requires the config module; it only receives options.
 --- @module 'blink-cmp-bibtex.matchers'
 
+local registry = require('blink-cmp-bibtex.registry')
+
 local M = {}
 
 --- Result returned by a matcher when the cursor sits inside a citation
@@ -27,73 +29,6 @@ local M = {}
 --- Default priority for matchers that do not declare one
 --- @type number
 local DEFAULT_PRIORITY = 50
-
---- Problems already reported, to keep notifications to one per key per session
---- @type table<string, boolean>
-local warned = {}
-
---- Stand-in filetype key for chains built without a filetype
---- @type string
-local NO_FILETYPE = '\0none'
-
---- Match functions that misbehaved, per filetype they misbehaved in
---- Keyed by the function itself so that a broken override in one filetype
---- never disables the same-named matcher elsewhere. Keys are weak so that
---- matchers belonging to discarded configurations can be collected.
---- @type table<function, table<string, boolean>>
-local failed = setmetatable({}, { __mode = 'k' })
-
---- Report a problem once per key per session
---- @param key string Identifies what the message is about
---- @param message string The message to display
-local function warn_once(key, message)
-  if warned[key] then
-    return
-  end
-  warned[key] = true
-  vim.notify(message, vim.log.levels.WARN, { title = 'blink-cmp-bibtex' })
-end
-
---- Whether a match function already misbehaved in this filetype
---- @param match function The match function
---- @param filetype string|nil The buffer filetype
---- @return boolean
-local function has_failed(match, filetype)
-  local per_filetype = failed[match]
-  return per_filetype ~= nil and per_filetype[filetype or NO_FILETYPE] == true
-end
-
---- Remember that a match function misbehaved in this filetype
---- @param match function The match function
---- @param filetype string|nil The buffer filetype
-local function mark_failed(match, filetype)
-  local per_filetype = failed[match]
-  if not per_filetype then
-    per_filetype = {}
-    failed[match] = per_filetype
-  end
-  per_filetype[filetype or NO_FILETYPE] = true
-end
-
---- Render an arbitrary error value as text
---- A matcher may throw anything, including a table whose __tostring itself
---- raises, so every conversion attempt is protected.
---- @param err any The value a matcher threw
---- @return string
-local function describe_error(err)
-  if type(err) == 'string' then
-    return err
-  end
-  local ok, rendered = pcall(vim.inspect, err)
-  if ok and type(rendered) == 'string' then
-    return rendered
-  end
-  ok, rendered = pcall(tostring, err)
-  if ok and type(rendered) == 'string' then
-    return rendered
-  end
-  return '<unprintable error>'
-end
 
 --- Describe why a matcher result is unusable, if it is
 --- @param result any The value a matcher returned
@@ -312,7 +247,7 @@ function M.normalize(name, value, filetype)
   if value == true then
     match = M.builtin[name]
     if not match then
-      warn_once(name, string.format("matcher '%s' is enabled but no built-in matcher has that name", name))
+      registry.warn_once(name, string.format("matcher '%s' is enabled but no built-in matcher has that name", name))
       return nil
     end
     inherited = shipped_spec(name, filetype)
@@ -321,14 +256,14 @@ function M.normalize(name, value, filetype)
   elseif type(value) == 'string' then
     match = M.builtin[value]
     if not match then
-      warn_once(name, string.format("matcher '%s' refers to unknown built-in matcher '%s'", name, value))
+      registry.warn_once(name, string.format("matcher '%s' refers to unknown built-in matcher '%s'", name, value))
       return nil
     end
     inherited = shipped_spec(value, filetype)
   elseif type(value) == 'table' then
     local reason = malformed_field_reason(value)
     if reason then
-      warn_once(name, string.format("matcher '%s' is skipped: %s", name, reason))
+      registry.warn_once(name, string.format("matcher '%s' is skipped: %s", name, reason))
       return nil
     end
     extra = value
@@ -337,13 +272,16 @@ function M.normalize(name, value, filetype)
     else
       match = M.builtin[name]
       if not match then
-        warn_once(name, string.format("matcher '%s' has no match function and no built-in matcher has that name", name))
+        registry.warn_once(
+          name,
+          string.format("matcher '%s' has no match function and no built-in matcher has that name", name)
+        )
         return nil
       end
       inherited = shipped_spec(name, filetype)
     end
   else
-    warn_once(name, string.format("matcher '%s' has unsupported type '%s'", name, type(value)))
+    registry.warn_once(name, string.format("matcher '%s' has unsupported type '%s'", name, type(value)))
     return nil
   end
 
@@ -413,20 +351,20 @@ end
 function M.detect(text, opts, ctx)
   local filetype = ctx and ctx.filetype
   for _, spec in ipairs(M.chain(filetype, opts)) do
-    if not has_failed(spec.match, filetype) then
+    if not registry.has_failed(spec.match, filetype) then
       local ok, result = pcall(spec.match, text, opts, ctx)
       -- A matcher that errors or answers with something unusable is skipped for
       -- this filetype rather than allowed to break completion downstream.
       local problem
       if not ok then
-        problem = string.format('raised an error: %s', describe_error(result))
+        problem = string.format('raised an error: %s', registry.describe_error(result))
       elseif result ~= nil and result ~= false then
         problem = malformed_reason(result)
       end
       if problem then
-        mark_failed(spec.match, filetype)
-        warn_once(
-          string.format('%s@%s', spec.name, filetype or NO_FILETYPE),
+        registry.mark_failed(spec.match, filetype)
+        registry.warn_once(
+          string.format('%s@%s', spec.name, filetype or registry.NO_FILETYPE),
           string.format("matcher '%s' %s and is disabled for filetype '%s'", spec.name, problem, filetype or 'unset')
         )
       elseif result then
@@ -458,10 +396,9 @@ end
 --- Internal helpers exposed for testing. Not part of the public API.
 M.__test = {
   --- Forget the per-session warning and failed-matcher state.
-  reset = function()
-    warned = {}
-    failed = setmetatable({}, { __mode = 'k' })
-  end,
+  --- Kept as an entry point of its own even though the state now lives in the
+  --- registry, so callers do not need to know where it is held.
+  reset = registry.reset,
 }
 
 return M

--- a/lua/blink-cmp-bibtex/matchers.lua
+++ b/lua/blink-cmp-bibtex/matchers.lua
@@ -14,6 +14,7 @@ local M = {}
 --- @field trigger string|nil Name of the syntax that matched
 --- @field command string|nil The citation command that matched, when applicable
 --- @field sanitize boolean|nil Override the prefix sanitization for this match
+--- @field separators string|nil Override the key separators for this match
 
 --- A matcher function
 --- @alias BibtexMatcherFn fun(text: string, opts: table, ctx: table|nil): BibtexMatchResult|nil
@@ -24,6 +25,7 @@ local M = {}
 --- @field match BibtexMatcherFn The matching function
 --- @field priority number Lower runs first (default 50)
 --- @field sanitize boolean|nil Whether matched prefixes are sanitized
+--- @field separators string|nil Characters separating keys in a multi-key citation
 --- @field trigger_characters string[]|nil Characters that should open the menu
 
 --- Default priority for matchers that do not declare one
@@ -164,11 +166,13 @@ M.builtin = {
 --- @type table<string, table<string, table>>
 M.defaults = {
   ['*'] = {
-    latex = { priority = 10 },
-    pandoc = { priority = 30 },
+    -- LaTeX separates keys with commas only; a semicolon is an ordinary
+    -- character in a key, which the parser accepts.
+    latex = { priority = 10, separators = ',' },
+    pandoc = { priority = 30, separators = ',;' },
   },
   typst = {
-    typst = { priority = 20 },
+    typst = { priority = 20, separators = ',' },
   },
   -- GAPDoc lives in filetypes that are not enabled by default; add 'gap',
   -- 'xml' or 'autodoc' to `filetypes` to activate these.
@@ -192,6 +196,9 @@ local function malformed_field_reason(spec)
   end
   if spec.sanitize ~= nil and type(spec.sanitize) ~= 'boolean' then
     return string.format('sanitize is %s instead of a boolean', type(spec.sanitize))
+  end
+  if spec.separators ~= nil and type(spec.separators) ~= 'string' then
+    return string.format('separators is %s instead of a string', type(spec.separators))
   end
   if spec.trigger_characters ~= nil then
     if type(spec.trigger_characters) ~= 'table' then
@@ -312,6 +319,7 @@ function M.normalize(name, value, filetype)
     match = match,
     priority = field('priority') or DEFAULT_PRIORITY,
     sanitize = field('sanitize'),
+    separators = field('separators'),
     trigger_characters = field('trigger_characters'),
   }
 end

--- a/lua/blink-cmp-bibtex/matchers.lua
+++ b/lua/blink-cmp-bibtex/matchers.lua
@@ -322,7 +322,18 @@ end
 --- @param opts table Configuration options
 --- @return BibtexMatcherSpec[] The matchers to run, in order
 function M.chain(filetype, opts)
-  local configured = opts and opts.matchers or {}
+  local configured = opts and opts.matchers
+  if configured == true then
+    configured = M.defaults
+  elseif configured ~= nil and type(configured) ~= 'table' then
+    -- false disables every matcher; anything else is unusable and is reported
+    -- once, then treated as though nothing had been configured.
+    if configured ~= false then
+      registry.warn_once('matcher', 'option', string.format('matchers is %s, which cannot be used', type(configured)))
+    end
+    configured = {}
+  end
+  configured = configured or {}
   local shared = configured['*'] or {}
   local per_filetype = filetype and configured[filetype] or {}
 

--- a/lua/blink-cmp-bibtex/path.lua
+++ b/lua/blink-cmp-bibtex/path.lua
@@ -1,0 +1,56 @@
+--- Path helpers shared by the scanner and the discovery hooks
+--- Extracted so that discovery.lua can resolve the paths it finds without
+--- depending on scan.lua, which depends on it.
+--- @module 'blink-cmp-bibtex.path'
+
+local M = {}
+
+--- Platform-specific path separator
+--- @type string
+local path_separator = package.config:sub(1, 1)
+
+--- Join two path components
+--- @param base string|nil Base path
+--- @param relative string|nil Relative path
+--- @return string|nil The joined path
+function M.joinpath(base, relative)
+  if base == nil or base == '' then
+    return relative
+  end
+  if relative == nil or relative == '' then
+    return base
+  end
+  if vim.fs and vim.fs.joinpath then
+    return vim.fs.joinpath(base, relative)
+  end
+  if base:sub(-1) == path_separator then
+    return base .. relative
+  end
+  return base .. path_separator .. relative
+end
+
+--- Normalize a path, expanding home directory and resolving relative paths
+--- @param path string|nil The path to normalize
+--- @return string|nil The normalized path or nil if invalid
+function M.normalize(path)
+  if not path or path == '' then
+    return nil
+  end
+  local uv = vim.uv or vim.loop
+  local home = uv.os_homedir()
+  if home then
+    path = path:gsub('^~', home)
+  end
+  path = vim.fn.expand(path)
+  path = vim.fs.normalize(path)
+  return path
+end
+
+--- Check if a path is absolute
+--- @param path string The path to check
+--- @return boolean True if the path is absolute
+function M.is_absolute(path)
+  return path:match('^%a:[\\/]') or path:sub(1, 1) == '/'
+end
+
+return M

--- a/lua/blink-cmp-bibtex/registry.lua
+++ b/lua/blink-cmp-bibtex/registry.lua
@@ -23,13 +23,17 @@ local warned = {}
 local failed = setmetatable({}, { __mode = 'k' })
 
 --- Report a problem once per key per session
---- @param key string Identifies what the message is about
+--- The consumer namespaces the key, so a matcher and a discovery hook that
+--- happen to share a name do not silence each other's warnings.
+--- @param consumer string Which registry is reporting, e.g. 'matcher'
+--- @param key string Identifies what the message is about within that registry
 --- @param message string The message to display
-function M.warn_once(key, message)
-  if warned[key] then
+function M.warn_once(consumer, key, message)
+  local namespaced = consumer .. ':' .. key
+  if warned[namespaced] then
     return
   end
-  warned[key] = true
+  warned[namespaced] = true
   vim.notify(message, vim.log.levels.WARN, { title = 'blink-cmp-bibtex' })
 end
 

--- a/lua/blink-cmp-bibtex/registry.lua
+++ b/lua/blink-cmp-bibtex/registry.lua
@@ -1,0 +1,84 @@
+--- Shared bookkeeping for the plugin's extension points
+--- Both the matcher chain and the discovery chain run user-supplied functions,
+--- and both must survive a misbehaving one: report the problem once, then stop
+--- calling that function in the filetype where it misbehaved. This module holds
+--- that state so the two chains cannot drift apart in how they handle it.
+--- @module 'blink-cmp-bibtex.registry'
+
+local M = {}
+
+--- Stand-in filetype key for chains built without a filetype
+--- @type string
+M.NO_FILETYPE = '\0none'
+
+--- Problems already reported, to keep notifications to one per key per session
+--- @type table<string, boolean>
+local warned = {}
+
+--- Functions that misbehaved, per filetype they misbehaved in
+--- Keyed by the function itself so that a broken override in one filetype never
+--- disables the same-named entry elsewhere. Keys are weak so that functions
+--- belonging to discarded configurations can be collected.
+--- @type table<function, table<string, boolean>>
+local failed = setmetatable({}, { __mode = 'k' })
+
+--- Report a problem once per key per session
+--- @param key string Identifies what the message is about
+--- @param message string The message to display
+function M.warn_once(key, message)
+  if warned[key] then
+    return
+  end
+  warned[key] = true
+  vim.notify(message, vim.log.levels.WARN, { title = 'blink-cmp-bibtex' })
+end
+
+--- Whether a function already misbehaved in this filetype
+--- @param fn function The registered function
+--- @param filetype string|nil The buffer filetype
+--- @return boolean
+function M.has_failed(fn, filetype)
+  local per_filetype = failed[fn]
+  return per_filetype ~= nil and per_filetype[filetype or M.NO_FILETYPE] == true
+end
+
+--- Remember that a function misbehaved in this filetype
+--- @param fn function The registered function
+--- @param filetype string|nil The buffer filetype
+function M.mark_failed(fn, filetype)
+  local per_filetype = failed[fn]
+  if not per_filetype then
+    per_filetype = {}
+    failed[fn] = per_filetype
+  end
+  per_filetype[filetype or M.NO_FILETYPE] = true
+end
+
+--- Render an arbitrary error value as text
+--- A registered function may throw anything, including a table whose __tostring
+--- itself raises, so every conversion attempt is protected.
+--- @param err any The value that was thrown
+--- @return string
+function M.describe_error(err)
+  if type(err) == 'string' then
+    return err
+  end
+  local ok, rendered = pcall(vim.inspect, err)
+  if ok and type(rendered) == 'string' then
+    return rendered
+  end
+  ok, rendered = pcall(tostring, err)
+  if ok and type(rendered) == 'string' then
+    return rendered
+  end
+  return '<unprintable error>'
+end
+
+--- Forget the per-session warning and failure state
+--- Exposed for tests, which need each case to start from a clean slate.
+function M.reset()
+  warned = {}
+  failed = setmetatable({}, { __mode = 'k' })
+end
+
+return M

--- a/lua/blink-cmp-bibtex/scan.lua
+++ b/lua/blink-cmp-bibtex/scan.lua
@@ -2,6 +2,9 @@
 --- Discovers and resolves BibTeX file paths from buffers and configuration
 --- @module 'blink-cmp-bibtex.scan'
 
+local discovery = require('blink-cmp-bibtex.discovery')
+local path_util = require('blink-cmp-bibtex.path')
+
 local M = {}
 
 --- Resolve an option value (may be a function or static value)
@@ -63,323 +66,6 @@ function M.resolve_option_list(value, ...)
   return normalize_list(resolve_option(value, ...))
 end
 
---- BibTeX bibliography command names to recognize
---- @type table<string, boolean>
-local bibliography_commands = {
-  addbibresource = true,
-  ['addbibresource*'] = true,
-  addglobalbib = true,
-  addsectionbib = true,
-  bibliography = true,
-  nobibliography = true,
-}
-
---- Trim whitespace from a string
---- @param value string The string to trim
---- @return string The trimmed string
-local function trim(value)
-  return value:match('^%s*(.-)%s*$') or ''
-end
-
---- Split a comma-separated resource string into individual entries
---- @param value string The resource string to split
---- @return string[] List of resource names
-local function split_resources(value)
-  local entries = {}
-  for part in value:gmatch('[^,]+') do
-    local cleaned = trim(part)
-    if cleaned ~= '' then
-      entries[#entries + 1] = cleaned
-    end
-  end
-  if #entries == 0 and value ~= '' then
-    entries[1] = trim(value)
-  end
-  return entries
-end
-
---- Skip whitespace in a string starting from a given index
---- @param str string The input string
---- @param idx number Starting index
---- @return number The next non-whitespace index
-local function skip_whitespace(str, idx)
-  while idx <= #str and str:sub(idx, idx):match('%s') do
-    idx = idx + 1
-  end
-  return idx
-end
-
---- Read a balanced block (e.g., braces) from a string
---- @param str string The input string
---- @param idx number Starting index
---- @return string|nil, number The extracted block and next index
-local function read_balanced_block(str, idx)
-  if str:sub(idx, idx) ~= '{' then
-    return nil, idx
-  end
-  local depth = 1
-  local cursor = idx + 1
-  while cursor <= #str and depth > 0 do
-    local ch = str:sub(cursor, cursor)
-    if ch == '{' then
-      depth = depth + 1
-    elseif ch == '}' then
-      depth = depth - 1
-      if depth == 0 then
-        return str:sub(idx + 1, cursor - 1), cursor + 1
-      end
-    elseif ch == '\\' and cursor < #str then
-      cursor = cursor + 1
-    end
-    cursor = cursor + 1
-  end
-  return nil, idx
-end
-
---- Skip optional arguments in a LaTeX command
---- @param str string The input string
---- @param idx number Starting index
---- @return number The index after all optional arguments
-local function skip_optional_arguments(str, idx)
-  local cursor = skip_whitespace(str, idx)
-  while str:sub(cursor, cursor) == '[' do
-    local depth = 1
-    cursor = cursor + 1
-    while cursor <= #str and depth > 0 do
-      local ch = str:sub(cursor, cursor)
-      if ch == '[' then
-        depth = depth + 1
-      elseif ch == ']' then
-        depth = depth - 1
-      end
-      cursor = cursor + 1
-    end
-    cursor = skip_whitespace(str, cursor)
-  end
-  return cursor
-end
-
---- Extract bibliography file paths from a LaTeX command line
---- @param line string The line to parse
---- @return string[] List of extracted file paths
-local function extract_command_paths(line)
-  local results = {}
-  local i = 1
-  while i <= #line do
-    local start_pos, end_pos, command = line:find('\\([%a%@]+%*?)', i)
-    if not start_pos then
-      break
-    end
-    i = end_pos + 1
-    if not bibliography_commands[command] then
-      goto continue
-    end
-    local cursor = skip_optional_arguments(line, i)
-    cursor = skip_whitespace(line, cursor)
-    local value
-    value, i = read_balanced_block(line, cursor)
-    if value and #value > 0 then
-      local resources = split_resources(value)
-      for _, resource in ipairs(resources) do
-        results[#results + 1] = resource
-      end
-    end
-    ::continue::
-  end
-  return results
-end
-
---- Find bibliography files in YAML front matter
---- @param lines string[] Buffer lines to search
---- @return string[] List of bibliography file paths
-local function find_yaml_bibliography(lines)
-  local resources = {}
-  local in_front_matter = false
-  local collecting_list = false
-  for idx, line in ipairs(lines) do
-    if idx == 1 and line:match('^%-%-%-%s*$') then
-      in_front_matter = true
-    elseif in_front_matter and line:match('^%-%-%-%s*$') then
-      break
-    elseif in_front_matter then
-      local inline = line:match('^bibliography:%s*(.+)$')
-      if inline then
-        resources[#resources + 1] = trim(inline)
-        collecting_list = false
-      elseif line:match('^bibliography:%s*$') then
-        collecting_list = true
-      elseif line:match('^%S') and not line:match('^%s') then
-        collecting_list = false
-      end
-      if collecting_list then
-        local list_item = line:match('^%s*%-%s*(.+)%s*$')
-        if list_item then
-          resources[#resources + 1] = trim(list_item)
-        end
-      end
-    end
-  end
-  return resources
-end
-
---- Find Typst import statements
---- @param lines string[] Buffer lines to search
---- @return string[] List of imported file paths
-local function find_typst_imports(lines)
-  local imports = {}
-  for _, line in ipairs(lines) do
-    -- Match #import patterns with double quotes:
-    -- #import "file.typ"
-    -- #import "file.typ": item
-    -- #import "file.typ": *
-    -- Capture the path within double quotes
-    for path in line:gmatch('#import%s+"([^"]+)"') do
-      if path:match('%.typ$') then
-        imports[#imports + 1] = trim(path)
-      end
-    end
-    -- Match #import patterns with single quotes:
-    -- #import 'file.typ'
-    -- #import 'file.typ': item
-    -- #import 'file.typ': *
-    -- Capture the path within single quotes
-    for path in line:gmatch("#import%s+'([^']+)'") do
-      if path:match('%.typ$') then
-        imports[#imports + 1] = trim(path)
-      end
-    end
-  end
-  return imports
-end
-
---- Read lines from a file
---- @param filepath string The file path to read
---- @return string[]|nil List of lines or nil if file cannot be read
-local function read_file_lines(filepath)
-  local fd = io.open(filepath, 'r')
-  if not fd then
-    -- Silently return nil for missing imports - this is expected in many cases
-    -- as users may import files that don't exist yet or are in different locations
-    return nil
-  end
-  local lines = {}
-  for line in fd:lines() do
-    lines[#lines + 1] = line
-  end
-  fd:close()
-  return lines
-end
-
---- Platform-specific path separator
---- @type string
-local path_separator = package.config:sub(1, 1)
-
---- Join two path components
---- @param base string|nil Base path
---- @param relative string|nil Relative path
---- @return string|nil The joined path
-local function joinpath(base, relative)
-  if base == nil or base == '' then
-    return relative
-  end
-  if relative == nil or relative == '' then
-    return base
-  end
-  if vim.fs and vim.fs.joinpath then
-    return vim.fs.joinpath(base, relative)
-  end
-  if base:sub(-1) == path_separator then
-    return base .. relative
-  end
-  return base .. path_separator .. relative
-end
-
---- Normalize a path, expanding home directory and resolving relative paths
---- @param path string|nil The path to normalize
---- @return string|nil The normalized path or nil if invalid
-local function normalize_path(path)
-  if not path or path == '' then
-    return nil
-  end
-  local uv = vim.uv or vim.loop
-  local home = uv.os_homedir()
-  if home then
-    path = path:gsub('^~', home)
-  end
-  path = vim.fn.expand(path)
-  path = vim.fs.normalize(path)
-  return path
-end
-
---- Check if a path is absolute
---- @param path string The path to check
---- @return boolean True if the path is absolute
-local function is_absolute(path)
-  return path:match('^%a:[\\/]') or path:sub(1, 1) == '/'
-end
-
---- Find bibliography files in Typst #bibliography() declarations
---- Recursively follows #import statements to find bibliographies in imported files
---- @param lines string[] Buffer lines to search
---- @param base_dir string|nil Directory to resolve relative imports from
---- @param visited table<string, boolean>|nil Table to track visited files (prevents cycles)
---- @return string[] List of bibliography file paths
-local function find_typst_bibliography(lines, base_dir, visited)
-  visited = visited or {}
-  local resources = {}
-
-  -- Find direct bibliography declarations
-  for _, line in ipairs(lines) do
-    -- Match #bibliography("path/to/file.bib") with double quotes
-    for path in line:gmatch('#bibliography%s*%(%s*"([^"]+)"%s*%)') do
-      path = trim(path)
-      if not is_absolute(path) and base_dir then
-        path = joinpath(base_dir, path) --[[@as string]]
-      end
-      resources[#resources + 1] = path
-    end
-    -- Match #bibliography('path/to/file.bib') with single quotes
-    for path in line:gmatch("#bibliography%s*%(%s*'([^']+)'%s*%)") do
-      path = trim(path)
-      if not is_absolute(path) and base_dir then
-        path = joinpath(base_dir, path) --[[@as string]]
-      end
-      resources[#resources + 1] = path
-    end
-  end
-
-  -- Follow imports to find bibliographies in imported files
-  if base_dir then
-    local imports = find_typst_imports(lines)
-    for _, import_path in ipairs(imports) do
-      local full_path
-      if is_absolute(import_path) then
-        full_path = normalize_path(import_path)
-      else
-        full_path = normalize_path(joinpath(base_dir, import_path))
-      end
-
-      if full_path and not visited[full_path] then
-        visited[full_path] = true
-        local import_lines = read_file_lines(full_path)
-        if import_lines then
-          local import_dir = vim.fs.dirname(full_path)
-          local imported_resources = find_typst_bibliography(import_lines, import_dir, visited)
-          for _, resource in ipairs(imported_resources) do
-            -- Resolve imported resource paths relative to the imported file's directory
-            if not is_absolute(resource) then
-              resource = joinpath(import_dir, resource) --[[@as string]]
-            end
-            resources[#resources + 1] = resource
-          end
-        end
-      end
-    end
-  end
-
-  return resources
-end
-
 --- Find the project root directory based on markers
 --- @param bufname string Buffer file name
 --- @param markers table List of root marker files/directories
@@ -404,7 +90,7 @@ end
 
 local function expand_search_path(path, root)
   local resolved = {}
-  if not is_absolute(path) then
+  if not path_util.is_absolute(path) then
     path = vim.fs.normalize(table.concat({ root, path }, '/'))
   end
   if path:find('[%*%?%[]') then
@@ -418,158 +104,13 @@ local function expand_search_path(path, root)
   return resolved
 end
 
---- Find bibliography databases in GAPDoc <Bibliography Databases="..."/> declarations
---- Per the GAPDoc DTD the element is EMPTY with a required Databases attribute
---- and an optional Style attribute; several databases are separated by commas.
---- BibTeX databases are named without their .bib extension, while BibXMLext
---- databases carry their full .xml name and are skipped here, since this plugin
---- reads BibTeX and Hayagriva rather than BibXMLext.
---- The opening of a GAPDoc bibliography declaration
---- @type string
-local BIBLIOGRAPHY_TAG = '<Bibliography'
-
---- Blank out the XML regions whose contents are not live markup
---- Comments, CDATA sections and processing instructions all hold text that an
---- XML processor never reads as markup, so a declaration inside one names a
---- bibliography that is not in use. An unterminated opener runs to the end of
---- the document, which is what an editor shows while such a region is being
---- typed. Regions are replaced by a space rather than removed so that the
---- markup around them cannot be glued together.
---- @param text string The document text
---- @return string The text with inactive regions blanked out
-local function strip_inactive_regions(text)
-  text = text:gsub('<!%-%-.-%-%->', ' ')
-  text = text:gsub('<!%[CDATA%[.-%]%]>', ' ')
-  text = text:gsub('<%?.-%?>', ' ')
-  -- A DOCTYPE may carry an internal subset, whose entity declarations hold
-  -- replacement text that is not markup until an entity is referenced. The
-  -- '[^>%[]*' guard keeps this from reaching past the DOCTYPE's own '>' into a
-  -- later element that happens to contain brackets.
-  text = text:gsub('<!DOCTYPE[^>%[]*%[.-%]%s*>', ' ')
-  text = text:gsub('<!DOCTYPE[^>]*>', ' ')
-  text = text:gsub('<!%-%-.*$', ' ')
-  text = text:gsub('<!%[CDATA%[.*$', ' ')
-  text = text:gsub('<%?.*$', ' ')
-  text = text:gsub('<!DOCTYPE.*$', ' ')
-  return text
-end
-
---- The character references XML predefines, which need no DTD declaration
---- @type table<string, string>
-local xml_entities = {
-  amp = '&',
-  lt = '<',
-  gt = '>',
-  quot = '"',
-  apos = "'",
-}
-
---- Resolve one XML character reference to the character it stands for
---- @param reference string The reference body, without the '&' and ';'
---- @return string|nil The character, or nil when the reference is not resolvable
-local function resolve_xml_reference(reference)
-  local code = tonumber(reference:match('^#[xX](%x+)$') or '', 16) or tonumber(reference:match('^#(%d+)$') or '')
-  if code then
-    if code < 1 or code > 0x10FFFF then
-      return nil
-    end
-    return vim.fn.nr2char(code, 1)
-  end
-  -- Entity names are case sensitive in XML, so they are looked up as written.
-  return xml_entities[reference]
-end
-
---- Decode the XML character references in an attribute value
---- An XML processor resolves these before GAPDoc ever sees the value, so this
---- runs before the value is split on commas. References that are not the five
---- predefined entities or a numeric escape are left as written.
---- @param value string The raw attribute value
---- @return string The decoded value
-local function decode_xml_references(value)
-  return (value:gsub('&(#?%w+);', resolve_xml_reference))
-end
-
---- Read the Databases attribute of a single <Bibliography> element
---- @param element string The element text, from '<Bibliography' to its '>'
---- @return string|nil The attribute value, or nil when the element has none
-local function read_databases_attribute(element)
-  return element:match('Databases%s*=%s*"([^"]*)"') or element:match("Databases%s*=%s*'([^']*)'")
-end
-
---- @param lines string[] Buffer lines to search
---- @return string[] File names as written in the Databases attribute with '.bib'
----   appended; entries may carry a directory part and may contain dots
-local function find_gapdoc_bibliography(lines)
-  -- Every buffer is scanned regardless of filetype, so the cost of joining the
-  -- lines is only paid once a declaration can actually be present.
-  local marked = false
-  for _, line in ipairs(lines) do
-    if line:find(BIBLIOGRAPHY_TAG, 1, true) then
-      marked = true
-      break
-    end
-  end
-  if not marked then
-    return {}
-  end
-
-  -- Joined so that a declaration split across lines is still found.
-  local text = strip_inactive_regions(table.concat(lines, '\n'))
-
-  local resources = {}
-  -- One pass in source order, reading both attribute quote styles as they come,
-  -- so that the returned list follows the document rather than the quoting.
-  local cursor = 1
-  while true do
-    local start_pos = text:find(BIBLIOGRAPHY_TAG .. '%s', cursor)
-    if not start_pos then
-      break
-    end
-    local rest = text:sub(start_pos)
-    -- Bounded by the element's own '>', so a Databases attribute belonging to a
-    -- later element is never read. The second form covers an element still
-    -- being typed at the end of the document, where no '>' exists yet.
-    local element = rest:match('^<Bibliography%s[^>]*>') or rest:match('^<Bibliography%s[^>]*$')
-    local databases = element and read_databases_attribute(element)
-    databases = databases and decode_xml_references(databases)
-    for _, name in ipairs(databases and split_resources(databases) or {}) do
-      -- BibXMLext databases carry their full .xml name and are skipped; every
-      -- other name is a BibTeX database, which the DTD defines as being
-      -- written without its .bib extension, so it is always appended.
-      if not name:lower():match('%.xml$') then
-        resources[#resources + 1] = name .. '.bib'
-      end
-    end
-    cursor = start_pos + #BIBLIOGRAPHY_TAG
-  end
-  return resources
-end
-
---- Ensure a path has a bibliography extension (.bib, .yml, or .yaml)
---- @param path string|nil The path to check
---- @return string|nil The path with .bib extension if needed (unless it already has .yml or .yaml)
-local function ensure_bib_extension(path)
-  if not path or path == '' then
-    return path
-  end
-  if path:find('[%*%?%[]') then
-    return path
-  end
-  -- Accept .bib, .yml, .yaml extensions as-is
-  if path:match('%.bib$') or path:match('%.ya?ml$') then
-    return path
-  end
-  local filename = path:match('([^/\\]+)$') or path
-  if filename:find('%.') then
-    return path
-  end
-  return path .. '.bib'
-end
-
 --- Find BibTeX files referenced in a buffer
+--- Runs the discovery hooks configured for the buffer's filetype; see
+--- discovery.lua for the hooks shipped with the plugin.
 --- @param bufnr number Buffer number
+--- @param opts table|nil Configuration options; the shipped hooks are used when omitted
 --- @return string[] List of bibliography file names (not full paths)
-function M.find_bib_files_from_buffer(bufnr)
+function M.find_bib_files_from_buffer(bufnr, opts)
   if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
     return {}
   end
@@ -585,27 +126,14 @@ function M.find_bib_files_from_buffer(bufnr)
     buffer_dir = vim.fs.dirname(bufname)
   end
 
-  local resources = {}
-  for _, line in ipairs(lines) do
-    for _, resource in ipairs(extract_command_paths(line)) do
-      resources[#resources + 1] = ensure_bib_extension(resource)
-    end
-  end
-  local yaml_resources = find_yaml_bibliography(lines)
-  for _, resource in ipairs(yaml_resources) do
-    resources[#resources + 1] = ensure_bib_extension(resource)
-  end
-  local typst_resources = find_typst_bibliography(lines, buffer_dir)
-  for _, resource in ipairs(typst_resources) do
-    resources[#resources + 1] = ensure_bib_extension(resource)
-  end
-  -- Already carries its .bib extension: GAPDoc names are extensionless by
-  -- definition, so ensure_bib_extension's dotted-name heuristics do not apply.
-  local gapdoc_resources = find_gapdoc_bibliography(lines)
-  for _, resource in ipairs(gapdoc_resources) do
-    resources[#resources + 1] = resource
-  end
-  return resources
+  return discovery.collect({
+    bufnr = bufnr,
+    filetype = vim.bo[bufnr].filetype,
+    lines = lines,
+    bufname = bufname,
+    dir = buffer_dir,
+    opts = opts or {},
+  })
 end
 
 --- Resolve all BibTeX file paths for a buffer
@@ -618,7 +146,7 @@ function M.resolve_bib_paths(bufnr, opts)
   local manual_files = M.resolve_option_list(opts.files, bufnr)
   local global_files = M.resolve_option_list(opts.global_files, bufnr)
   local search_paths = M.resolve_option_list(opts.search_paths, bufnr)
-  local buffer_files = M.find_bib_files_from_buffer(bufnr)
+  local buffer_files = M.find_bib_files_from_buffer(bufnr, opts)
   local bufname = vim.api.nvim_buf_get_name(bufnr)
   local root = find_root(bufname, opts.root_markers or {})
   local buffer_dir = nil
@@ -637,11 +165,11 @@ function M.resolve_bib_paths(bufnr, opts)
       return
     end
     local expanded
-    if is_absolute(path) then
-      expanded = normalize_path(path)
+    if path_util.is_absolute(path) then
+      expanded = path_util.normalize(path)
     else
       local anchor = base_dir or root or buffer_dir
-      expanded = normalize_path(joinpath(anchor, path))
+      expanded = path_util.normalize(path_util.joinpath(anchor, path))
     end
     if expanded and not dedup[expanded] then
       dedup[expanded] = true

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -113,6 +113,89 @@ describe('config', function()
     assert.is_false(opts.discovery.rst.mine)
   end)
 
+  describe('non-table option values', function()
+    --- Run a function with vim.notify silenced.
+    --- @param fn function
+    --- @return any
+    local function quietly(fn)
+      local original = vim.notify
+      --- @diagnostic disable-next-line: duplicate-set-field
+      vim.notify = function(_msg, _level, _opts) end
+      local ok, result = pcall(fn)
+      --- @diagnostic disable-next-line: duplicate-set-field
+      vim.notify = original
+      if not ok then
+        error(result, 0)
+      end
+      return result
+    end
+
+    -- Every one of these used to crash a completion round, the scanner or the
+    -- health check rather than being reported and ignored.
+    local scalars = { ['true'] = true, ['false'] = false, ['a string'] = 'x', ['a number'] = 42 }
+    local table_options = { 'matchers', 'discovery', 'local_bib', 'filetypes', 'citation_commands', 'root_markers' }
+
+    for _, name in ipairs(table_options) do
+      for label, value in pairs(scalars) do
+        it(string.format('replaces %s = %s with something usable', name, label), function()
+          local opts = quietly(function()
+            return config.setup({ [name] = value })
+          end)
+          local resolved = opts[name]
+          if (name == 'matchers' or name == 'discovery') and type(resolved) == 'boolean' then
+            -- The registries keep false, which disables them, and it is a
+            -- boolean rather than a table by design.
+            assert.is_false(resolved)
+          else
+            assert.are.equal('table', type(resolved), name .. ' = ' .. label)
+          end
+        end)
+      end
+    end
+
+    it('reads registry = true as the shipped entries', function()
+      assert.are.same(config.defaults().discovery, config.setup({ discovery = true }).discovery)
+      assert.are.same(config.defaults().matchers, config.setup({ matchers = true }).matchers)
+    end)
+
+    it('keeps registry = false, which disables the chain', function()
+      assert.is_false(config.setup({ discovery = false }).discovery)
+      assert.is_false(config.setup({ matchers = false }).matchers)
+    end)
+
+    it('keeps a string or function path option, which are both supported', function()
+      assert.are.equal('refs.bib', config.setup({ files = 'refs.bib' }).files)
+      local fn = function() end
+      assert.are.equal(fn, config.setup({ global_files = fn }).global_files)
+    end)
+
+    it('replaces a path option that is neither a list, a string nor a function', function()
+      local opts = quietly(function()
+        return config.setup({ files = 42 })
+      end)
+      assert.are.same({}, opts.files)
+    end)
+
+    it('warns once about an unusable value', function()
+      local messages = {}
+      local original = vim.notify
+      --- @diagnostic disable-next-line: duplicate-set-field
+      vim.notify = function(msg, _level, _opts)
+        messages[#messages + 1] = msg
+      end
+      local ok = pcall(function()
+        require('blink-cmp-bibtex.registry').reset()
+        config.setup({ filetypes = 42 })
+        config.setup({ filetypes = 42 })
+      end)
+      --- @diagnostic disable-next-line: duplicate-set-field
+      vim.notify = original
+      assert.is_true(ok)
+      assert.are.equal(1, #messages)
+      assert.is_truthy(messages[1]:find("option 'filetypes' is number", 1, true))
+    end)
+  end)
+
   it('setup with nil resets to the defaults', function()
     config.setup({ preview_style = 'ieee' })
     local reset = config.setup(nil)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -100,6 +100,19 @@ describe('config', function()
     end
   end)
 
+  it('keeps discovery = false through setup, unlike an empty table', function()
+    -- An empty map merges into the shipped hooks and therefore cannot express
+    -- "discover nothing"; false replaces the table outright.
+    assert.is_false(config.setup({ discovery = false }).discovery)
+    assert.is_not_nil(config.setup({ discovery = {} }).discovery['*'])
+  end)
+
+  it('merges a user discovery hook without clobbering the shipped ones', function()
+    local opts = config.setup({ discovery = { rst = { mine = false } } })
+    assert.are.equal(10, opts.discovery['*'].latex.priority)
+    assert.is_false(opts.discovery.rst.mine)
+  end)
+
   it('setup with nil resets to the defaults', function()
     config.setup({ preview_style = 'ieee' })
     local reset = config.setup(nil)

--- a/tests/context_spec.lua
+++ b/tests/context_spec.lua
@@ -152,6 +152,14 @@ describe('sanitize_prefix', function()
     end)
   end
 
+  it('splits only on the separators it is given', function()
+    -- The separator set is per syntax: a semicolon ends a key in Pandoc but is
+    -- an ordinary character in a LaTeX key.
+    assert.are.equal('a;b', sanitize_prefix('a;b', ','))
+    assert.are.equal('b', sanitize_prefix('a;b', ',;'))
+    assert.are.equal('c', sanitize_prefix('a;b,c', ','))
+  end)
+
   it('returns an empty string for nil', function()
     assert.are.equal('', sanitize_prefix(nil))
   end)

--- a/tests/discovery_spec.lua
+++ b/tests/discovery_spec.lua
@@ -177,6 +177,58 @@ describe('discovery.chain', function()
   end)
 end)
 
+describe('discovery and matcher warnings', function()
+  local matchers = require('blink-cmp-bibtex.matchers')
+
+  before_each(function()
+    discovery.__test.reset()
+  end)
+
+  it('warns separately for a hook and a matcher sharing a name', function()
+    -- The two registries share the warn-once bookkeeping, so their keys must be
+    -- namespaced or the first warning would silence the second.
+    with_notify_capture(function(messages)
+      assert.is_nil(discovery.normalize('gapdoc', 42))
+      assert.is_nil(matchers.normalize('gapdoc', 42))
+      assert.are.equal(2, #messages)
+      assert.is_truthy(messages[1]:find('discovery hook', 1, true))
+      assert.is_truthy(messages[2]:find('matcher', 1, true))
+    end)
+  end)
+
+  it('still warns only once per registry for the same name', function()
+    with_notify_capture(function(messages)
+      discovery.normalize('gapdoc', 42)
+      discovery.normalize('gapdoc', 42)
+      assert.are.equal(1, #messages)
+    end)
+  end)
+
+  it('warns separately for a failing hook and a failing matcher of one name', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          shared = function()
+            error('boom')
+          end,
+        },
+      },
+      matchers = {
+        ['*'] = {
+          shared = function()
+            error('boom')
+          end,
+        },
+      },
+    }
+    with_notify_capture(function(messages)
+      discovery.collect(ctx(opts, {}, 'tex'))
+      matchers.detect('text', opts, { filetype = 'tex' })
+      assert.are.equal(2, #messages)
+    end)
+  end)
+end)
+
 describe('discovery.collect', function()
   before_each(function()
     discovery.__test.reset()

--- a/tests/discovery_spec.lua
+++ b/tests/discovery_spec.lua
@@ -1,0 +1,340 @@
+--- Tests for discovery hook registration and dispatch.
+
+local assert = require('luassert')
+local discovery = require('blink-cmp-bibtex.discovery')
+local config = require('blink-cmp-bibtex.config')
+
+--- Collect the names of a chain, in order.
+--- @param chain table[]
+--- @return string[]
+local function names(chain)
+  return vim.tbl_map(function(spec)
+    return spec.name
+  end, chain)
+end
+
+--- Run a function with vim.notify replaced by a recorder.
+--- @param fn function Receives the list that collects the messages
+--- @return any The value returned by fn
+local function with_notify_capture(fn)
+  local messages = {}
+  local original = vim.notify
+  --- @diagnostic disable-next-line: duplicate-set-field
+  vim.notify = function(msg)
+    messages[#messages + 1] = msg
+  end
+  local ok, result = pcall(fn, messages)
+  vim.notify = original
+  if not ok then
+    error(result, 0)
+  end
+  return result
+end
+
+--- Build a discovery context.
+--- @param opts table|nil Configuration options
+--- @param lines string[]|nil Buffer lines
+--- @param filetype string|nil
+--- @return BibtexDiscoveryContext
+local function ctx(opts, lines, filetype)
+  return {
+    bufnr = 0,
+    filetype = filetype or 'markdown',
+    lines = lines or {},
+    bufname = '/tmp/doc.md',
+    dir = '/tmp',
+    opts = opts or {},
+  }
+end
+
+describe('discovery.normalize', function()
+  before_each(function()
+    discovery.__test.reset()
+  end)
+
+  it('wraps a function into a spec with the default priority', function()
+    local fn = function() end
+    local spec = assert(discovery.normalize('custom', fn))
+    assert.are.equal(fn, spec.find)
+    assert.are.equal('custom', spec.name)
+    assert.are.equal(50, spec.priority)
+  end)
+
+  it('keeps the find function and options of a spec table', function()
+    local fn = function() end
+    local spec = assert(discovery.normalize('custom', { find = fn, priority = 3, extension = false }))
+    assert.are.equal(fn, spec.find)
+    assert.are.equal(3, spec.priority)
+    assert.is_false(spec.extension)
+  end)
+
+  it('falls back to the built-in hook named by the key', function()
+    local spec = assert(discovery.normalize('yaml', { priority = 20 }))
+    assert.are.equal(discovery.yaml, spec.find)
+    assert.are.equal(20, spec.priority)
+  end)
+
+  it('resolves a string to the named built-in hook', function()
+    assert.are.equal(discovery.latex, assert(discovery.normalize('commands', 'latex')).find)
+  end)
+
+  it('resolves true to the built-in hook named by the key', function()
+    assert.are.equal(discovery.typst, assert(discovery.normalize('typst', true)).find)
+  end)
+
+  it('inherits the shipped extension flag when a hook is re-enabled with true', function()
+    -- GAPDoc appends its own extension, and that must survive re-enabling it.
+    local spec = assert(discovery.normalize('gapdoc', true))
+    assert.is_false(spec.extension)
+    assert.are.equal(40, spec.priority)
+  end)
+
+  it('treats false and nil as disabled', function()
+    assert.is_nil(discovery.normalize('latex', false))
+    assert.is_nil(discovery.normalize('latex', nil))
+  end)
+
+  it('skips invalid values with a warning instead of throwing', function()
+    with_notify_capture(function(messages)
+      assert.is_nil(discovery.normalize('nosuch', true))
+      assert.is_nil(discovery.normalize('alias', 'nosuch'))
+      assert.is_nil(discovery.normalize('table', { priority = 1 }))
+      assert.is_nil(discovery.normalize('number', 42))
+      assert.are.equal(4, #messages)
+    end)
+  end)
+
+  it('skips a spec whose optional fields are malformed', function()
+    local malformed = {
+      { spec = { priority = 'high' }, reason = 'priority is string' },
+      { spec = { extension = 'yes' }, reason = 'extension is string' },
+    }
+    for _, case in ipairs(malformed) do
+      discovery.__test.reset()
+      with_notify_capture(function(messages)
+        case.spec.find = function() end
+        assert.is_nil(discovery.normalize('custom', case.spec))
+        assert.are.equal(1, #messages)
+        assert.is_truthy(messages[1]:find(case.reason, 1, true), messages[1])
+      end)
+    end
+  end)
+end)
+
+describe('discovery.chain', function()
+  before_each(function()
+    discovery.__test.reset()
+  end)
+
+  it('runs the shipped hooks in their documented order', function()
+    assert.are.same({ 'latex', 'yaml', 'typst', 'gapdoc' }, names(discovery.chain('markdown', config.defaults())))
+  end)
+
+  it('falls back to the shipped hooks when no discovery is configured', function()
+    -- find_bib_files_from_buffer is public and is called without options.
+    assert.are.same(names(discovery.chain('markdown', config.defaults())), names(discovery.chain('markdown', {})))
+    assert.are.same(names(discovery.chain('markdown', config.defaults())), names(discovery.chain('markdown', nil)))
+  end)
+
+  it('discovers nothing when discovery is configured as empty', function()
+    assert.are.same({}, discovery.chain('markdown', { discovery = {} }))
+  end)
+
+  it('lets a filetype entry override the priority of a shared entry', function()
+    local opts = {
+      discovery = {
+        ['*'] = { latex = { priority = 10 }, yaml = { priority = 20 } },
+        markdown = { yaml = { priority = 1 } },
+      },
+    }
+    assert.are.same({ 'yaml', 'latex' }, names(discovery.chain('markdown', opts)))
+    assert.are.same({ 'latex', 'yaml' }, names(discovery.chain('tex', opts)))
+  end)
+
+  it('lets a filetype entry disable a shared entry with false', function()
+    local opts = {
+      discovery = {
+        ['*'] = { latex = { priority = 10 }, yaml = { priority = 20 } },
+        markdown = { yaml = false },
+      },
+    }
+    assert.are.same({ 'latex' }, names(discovery.chain('markdown', opts)))
+    assert.are.same({ 'latex', 'yaml' }, names(discovery.chain('tex', opts)))
+  end)
+
+  it('breaks ties on the hook name', function()
+    local opts = {
+      discovery = { ['*'] = { zulu = function() end, alpha = function() end, mike = function() end } },
+    }
+    assert.are.same({ 'alpha', 'mike', 'zulu' }, names(discovery.chain('tex', opts)))
+  end)
+end)
+
+describe('discovery.collect', function()
+  before_each(function()
+    discovery.__test.reset()
+  end)
+
+  it('concatenates the results of the chain in order', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          second = {
+            priority = 2,
+            find = function()
+              return { 'b.bib' }
+            end,
+          },
+          first = {
+            priority = 1,
+            find = function()
+              return { 'a.bib' }
+            end,
+          },
+        },
+      },
+    }
+    assert.are.same({ 'a.bib', 'b.bib' }, discovery.collect(ctx(opts)))
+  end)
+
+  it('accepts a bare string as a single result', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          one = function()
+            return 'refs.bib'
+          end,
+        },
+      },
+    }
+    assert.are.same({ 'refs.bib' }, discovery.collect(ctx(opts)))
+  end)
+
+  it('tolerates a hook that reports nothing', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          none = function()
+            return nil
+          end,
+        },
+      },
+    }
+    assert.are.same({}, discovery.collect(ctx(opts)))
+  end)
+
+  it('appends .bib to an extensionless result', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          one = function()
+            return 'refs'
+          end,
+        },
+      },
+    }
+    assert.are.same({ 'refs.bib' }, discovery.collect(ctx(opts)))
+  end)
+
+  it('leaves the result alone when the hook declares extension = false', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          one = {
+            extension = false,
+            find = function()
+              return 'refs'
+            end,
+          },
+        },
+      },
+    }
+    assert.are.same({ 'refs' }, discovery.collect(ctx(opts)))
+  end)
+
+  it('receives a context carrying the buffer, filetype, lines and directory', function()
+    local seen
+    local opts = {
+      discovery = {
+        ['*'] = {
+          spy = function(context)
+            seen = context
+            return nil
+          end,
+        },
+      },
+    }
+    discovery.collect(ctx(opts, { 'a line' }, 'rst'))
+    assert.are.equal('rst', seen.filetype)
+    assert.are.same({ 'a line' }, seen.lines)
+    assert.are.equal('/tmp', seen.dir)
+    assert.are.equal(0, seen.bufnr)
+    assert.are.equal(opts, seen.opts)
+  end)
+
+  it('skips a throwing hook, warns once, and keeps the rest of the chain', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          broken = {
+            priority = 1,
+            find = function()
+              error('boom')
+            end,
+          },
+          good = {
+            priority = 2,
+            find = function()
+              return 'refs.bib'
+            end,
+          },
+        },
+      },
+    }
+    with_notify_capture(function(messages)
+      assert.are.same({ 'refs.bib' }, discovery.collect(ctx(opts)))
+      assert.are.same({ 'refs.bib' }, discovery.collect(ctx(opts)))
+      assert.are.equal(1, #messages)
+    end)
+  end)
+
+  it('skips a hook whose result is malformed', function()
+    local opts = {
+      discovery = {
+        ['*'] = {
+          bogus = {
+            priority = 1,
+            find = function()
+              return { 'ok.bib', 42 }
+            end,
+          },
+          good = {
+            priority = 2,
+            find = function()
+              return 'refs.bib'
+            end,
+          },
+        },
+      },
+    }
+    with_notify_capture(function(messages)
+      assert.are.same({ 'refs.bib' }, discovery.collect(ctx(opts)))
+      assert.are.equal(1, #messages)
+      assert.is_truthy(messages[1]:find('instead of a file name', 1, true))
+    end)
+  end)
+
+  it('keeps a hook that failed in one filetype running in another', function()
+    local shared = function(context)
+      if context.filetype == 'markdown' then
+        error('boom')
+      end
+      return 'refs.bib'
+    end
+    local opts = { discovery = { ['*'] = { shared = shared } } }
+    with_notify_capture(function()
+      assert.are.same({}, discovery.collect(ctx(opts, {}, 'markdown')))
+      assert.are.same({ 'refs.bib' }, discovery.collect(ctx(opts, {}, 'tex')))
+    end)
+  end)
+end)

--- a/tests/discovery_spec.lua
+++ b/tests/discovery_spec.lua
@@ -136,7 +136,10 @@ describe('discovery.chain', function()
     assert.are.same(names(discovery.chain('markdown', config.defaults())), names(discovery.chain('markdown', nil)))
   end)
 
-  it('discovers nothing when discovery is configured as empty', function()
+  it('discovers nothing when discovery is turned off', function()
+    assert.are.same({}, discovery.chain('markdown', { discovery = false }))
+    -- An empty table says the same thing, but only survives when the options
+    -- are passed straight through rather than merged by setup().
     assert.are.same({}, discovery.chain('markdown', { discovery = {} }))
   end)
 

--- a/tests/discovery_spec.lua
+++ b/tests/discovery_spec.lua
@@ -19,11 +19,15 @@ end
 local function with_notify_capture(fn)
   local messages = {}
   local original = vim.notify
+  -- The full signature matters: the language server merges every assignment to
+  -- vim.notify across the workspace, so a stub taking one parameter would
+  -- redefine the function project-wide and flag every real three-argument call.
   --- @diagnostic disable-next-line: duplicate-set-field
-  vim.notify = function(msg)
+  vim.notify = function(msg, _level, _opts)
     messages[#messages + 1] = msg
   end
   local ok, result = pcall(fn, messages)
+  --- @diagnostic disable-next-line: duplicate-set-field
   vim.notify = original
   if not ok then
     error(result, 0)

--- a/tests/fixtures/project/mixed.md
+++ b/tests/fixtures/project/mixed.md
@@ -1,0 +1,10 @@
+---
+bibliography: shared.bib
+---
+
+# Mixed declarations
+
+This document declares a bibliography twice, in two syntaxes, so that the
+order in which they are discovered is pinned by the test suite.
+
+\addbibresource{bib/refs.bib}

--- a/tests/health_spec.lua
+++ b/tests/health_spec.lua
@@ -121,6 +121,39 @@ describe('health.check', function()
     assert.is_truthy(find(calls.warn, 'no matchers are configured'))
   end)
 
+  it('reports the discovery chain', function()
+    config.setup(nil)
+    local message = assert(find(run_check().info, 'latex (priority 10), yaml (priority 20)'))
+    assert.is_truthy(message:find('typst (priority 30), gapdoc (priority 40)', 1, true))
+  end)
+
+  it('warns when buffer discovery is turned off', function()
+    config.setup({ discovery = false })
+    assert.is_truthy(find(run_check().warn, 'buffer discovery is disabled'))
+  end)
+
+  it('warns about discovery hooks for a filetype outside the filetypes list', function()
+    config.setup({ discovery = { rst = { mine = function() end } } })
+    local message = assert(find(run_check().warn, "discovery for 'rst'"))
+    assert.is_truthy(message:find('bibliographies will not be discovered there', 1, true))
+  end)
+
+  it('still reports discovery when no matchers are configured', function()
+    -- The matcher section used to return early, which hid everything below it.
+    local original = config.get
+    --- @diagnostic disable-next-line: duplicate-set-field
+    config.get = function()
+      local resolved = vim.deepcopy(original())
+      resolved.matchers = {}
+      return resolved
+    end
+    local ok, calls = pcall(run_check)
+    config.get = original
+    assert.is_true(ok, tostring(calls))
+    assert.is_truthy(find(calls.warn, 'no matchers are configured'))
+    assert.is_truthy(find(calls.info, 'latex (priority 10), yaml (priority 20)'))
+  end)
+
   it('warns about matchers for a filetype outside the filetypes list', function()
     config.setup({ matchers = { cobol = { latex = true } } })
     assert.is_truthy(find(run_check().warn, "matchers for 'cobol'"))

--- a/tests/matchers_spec.lua
+++ b/tests/matchers_spec.lua
@@ -19,10 +19,15 @@ end
 local function with_notify_capture(fn)
   local messages = {}
   local original = vim.notify
-  vim.notify = function(msg)
+  -- The full signature matters: the language server merges every assignment to
+  -- vim.notify across the workspace, so a stub taking one parameter would
+  -- redefine the function project-wide and flag every real three-argument call.
+  --- @diagnostic disable-next-line: duplicate-set-field
+  vim.notify = function(msg, _level, _opts)
     messages[#messages + 1] = msg
   end
   local ok, result = pcall(fn, messages)
+  --- @diagnostic disable-next-line: duplicate-set-field
   vim.notify = original
   if not ok then
     error(result, 0)

--- a/tests/matchers_spec.lua
+++ b/tests/matchers_spec.lua
@@ -119,6 +119,21 @@ describe('matchers.normalize', function()
     end)
   end)
 
+  it('rejects a non-string separators field', function()
+    matchers.__test.reset()
+    with_notify_capture(function(messages)
+      assert.is_nil(matchers.normalize('custom', { match = function() end, separators = 42 }))
+      assert.are.equal(1, #messages)
+      assert.is_truthy(messages[1]:find('separators is number', 1, true))
+    end)
+  end)
+
+  it('carries the shipped separators of a built-in', function()
+    -- LaTeX lists keys with commas only, Pandoc also with semicolons.
+    assert.are.equal(',', assert(matchers.normalize('latex', true)).separators)
+    assert.are.equal(',;', assert(matchers.normalize('pandoc', true)).separators)
+  end)
+
   it('accepts well formed optional fields', function()
     local spec = assert(matchers.normalize('custom', {
       match = function() end,

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -25,6 +25,65 @@ describe('scan.find_bib_files_from_buffer', function()
   end)
 end)
 
+describe('scan.find_bib_files_from_buffer built-in order', function()
+  -- Pins the behavior the discovery hooks must reproduce: which syntaxes are
+  -- read, in which order, and which names come back with an extension.
+
+  it('returns raw names, LaTeX before YAML, for a buffer declaring both', function()
+    local bufnr = open_fixture('project/mixed.md', 'markdown')
+    assert.are.same({ 'bib/refs.bib', 'shared.bib' }, scan.find_bib_files_from_buffer(bufnr))
+  end)
+
+  it('appends .bib to extensionless LaTeX, YAML and Typst names', function()
+    local bufnr = helpers.make_buf({
+      lines = {
+        '---',
+        'bibliography: fromyaml',
+        '---',
+        '\\addbibresource{fromlatex}',
+        '#bibliography("fromtypst")',
+      },
+      filetype = 'markdown',
+    })
+    assert.are.same({ 'fromlatex.bib', 'fromyaml.bib', 'fromtypst.bib' }, scan.find_bib_files_from_buffer(bufnr))
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('leaves a dotted GAPDoc name alone, which already carries its extension', function()
+    local bufnr = helpers.make_buf({ lines = { '<Bibliography Databases="refs.v2"/>' }, filetype = 'xml' })
+    assert.are.same({ 'refs.v2.bib' }, scan.find_bib_files_from_buffer(bufnr))
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('resolves a Typst import relative to the imported file, not the importer', function()
+    helpers.with_tmpdir(function(dir)
+      local nested = vim.fs.joinpath(dir, 'nested')
+      helpers.write_file(vim.fs.joinpath(nested, 'template.typ'), '#bibliography("refs.bib")\n')
+      helpers.write_file(vim.fs.joinpath(dir, 'main.typ'), '#import "nested/template.typ": *\n')
+      local bufnr = vim.fn.bufadd(vim.fs.joinpath(dir, 'main.typ'))
+      vim.fn.bufload(bufnr)
+      vim.api.nvim_set_option_value('filetype', 'typst', { buf = bufnr })
+      -- Resolved, since the import path is derived from the buffer name and the
+      -- temporary directory reaches it through a symlink on macOS.
+      local expected = vim.fs.joinpath(vim.fs.normalize(vim.fn.resolve(nested)), 'refs.bib')
+      assert.are.same({ expected }, scan.find_bib_files_from_buffer(bufnr))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
+  it('passes an absolute Typst bibliography path through unchanged', function()
+    helpers.with_tmpdir(function(dir)
+      local absolute = vim.fs.joinpath(dir, 'refs.bib')
+      local bufnr = helpers.make_buf({
+        lines = { string.format('#bibliography("%s")', absolute) },
+        filetype = 'typst',
+      })
+      assert.are.same({ absolute }, scan.find_bib_files_from_buffer(bufnr))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+end)
+
 describe('scan.resolve_bib_paths', function()
   local fixtures = helpers.fixture('')
 
@@ -49,6 +108,15 @@ describe('scan.resolve_bib_paths', function()
   it('resolves #bibliography() and follows #import statements', function()
     local paths = scan.resolve_bib_paths(open_fixture('project/doc.typ', 'typst'), {})
     -- shared.bib is only declared inside the imported template.typ.
+    assert.are.same({
+      helpers.fixture('project/bib/refs.bib'),
+      helpers.fixture('project/shared.bib'),
+    }, paths)
+  end)
+
+  it('resolves every declaration of a buffer that mixes syntaxes', function()
+    -- Pins that discovery still runs when no options are configured at all.
+    local paths = scan.resolve_bib_paths(open_fixture('project/mixed.md', 'markdown'), {})
     assert.are.same({
       helpers.fixture('project/bib/refs.bib'),
       helpers.fixture('project/shared.bib'),

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -479,3 +479,81 @@ describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
     assert.is_true(ok, tostring(err))
   end)
 end)
+
+describe('scan discovery hooks', function()
+  local discovery = require('blink-cmp-bibtex.discovery')
+
+  before_each(function()
+    discovery.__test.reset()
+  end)
+
+  --- Options carrying a single user hook alongside the shipped ones.
+  --- @param entry any The configured value for the hook
+  --- @param filetype string|nil The filetype key to register it under
+  --- @return table
+  local function with_hook(entry, filetype)
+    local opts = { discovery = vim.deepcopy(discovery.defaults) }
+    if filetype then
+      opts.discovery[filetype] = { mine = entry }
+    else
+      opts.discovery['*'].mine = entry
+    end
+    return opts
+  end
+
+  it('resolves a relative path from a user hook against the buffer directory', function()
+    local bufnr = vim.fn.bufadd(helpers.fixture('project/doc.md'))
+    vim.fn.bufload(bufnr)
+    local opts = with_hook(function()
+      return 'bib/refs.bib'
+    end)
+    -- The YAML declaration in the fixture resolves to the same file.
+    assert.are.same({ helpers.fixture('project/bib/refs.bib') }, scan.resolve_bib_paths(bufnr, opts))
+  end)
+
+  it('passes an absolute path from a user hook through', function()
+    local bufnr = helpers.make_buf({ lines = { '' }, filetype = 'markdown' })
+    local opts = with_hook(function()
+      return helpers.fixture('refs.bib')
+    end)
+    assert.are.same({ helpers.fixture('refs.bib') }, scan.resolve_bib_paths(bufnr, opts))
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('gives the hook a context describing the buffer', function()
+    local seen
+    local bufnr = vim.fn.bufadd(helpers.fixture('project/doc.md'))
+    vim.fn.bufload(bufnr)
+    vim.api.nvim_set_option_value('filetype', 'markdown', { buf = bufnr })
+    scan.find_bib_files_from_buffer(
+      bufnr,
+      with_hook(function(context)
+        seen = context
+        return nil
+      end)
+    )
+    assert.are.equal(bufnr, seen.bufnr)
+    assert.are.equal('markdown', seen.filetype)
+    assert.are.equal(helpers.fixture('project'), vim.fs.normalize(seen.dir))
+    assert.is_true(#seen.lines > 0)
+  end)
+
+  it('drops only the disabled built-in for the filetype it is disabled in', function()
+    local opts = { discovery = vim.deepcopy(discovery.defaults) }
+    opts.discovery.markdown = { yaml = false }
+    local bufnr = open_fixture('project/mixed.md', 'markdown')
+    -- The LaTeX declaration survives; only the YAML one is dropped.
+    assert.are.same({ 'bib/refs.bib' }, scan.find_bib_files_from_buffer(bufnr, opts))
+    assert.are.same({ 'bib/refs.bib', 'shared.bib' }, scan.find_bib_files_from_buffer(bufnr, { discovery = nil }))
+  end)
+
+  it('discovers nothing from the buffer when discovery is configured as empty', function()
+    local bufnr = open_fixture('project/mixed.md', 'markdown')
+    assert.are.same({}, scan.find_bib_files_from_buffer(bufnr, { discovery = {} }))
+    -- Explicitly configured files are unaffected.
+    assert.are.same(
+      { helpers.fixture('refs.bib') },
+      scan.resolve_bib_paths(bufnr, { discovery = {}, files = { helpers.fixture('refs.bib') } })
+    )
+  end)
+end)

--- a/tests/source_spec.lua
+++ b/tests/source_spec.lua
@@ -250,6 +250,40 @@ describe('Source:resolve', function()
   end)
 end)
 
+describe('Source:get_completions with semicolons in keys', function()
+  local bufnr, dir, bib
+
+  before_each(function()
+    dir = vim.fs.normalize(vim.fn.tempname())
+    vim.fn.mkdir(dir, 'p')
+    bib = vim.fs.joinpath(dir, 'refs.bib')
+    helpers.write_file(bib, '@article{alpha;beta,\n  title = {Semicolon Key}\n}\n@article{beta,\n  title = {Plain}\n}')
+    cache.invalidate(bib)
+    bufnr = helpers.make_buf({ lines = { '' }, filetype = 'tex' })
+  end)
+
+  after_each(function()
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+    vim.fn.delete(dir, 'rf')
+  end)
+
+  it('filters on the whole key when a LaTeX citation contains a semicolon', function()
+    -- The semicolon used to split the prefix in every syntax, so this filtered
+    -- on 'bet' and offered the wrong entry.
+    local source = Source.new({ files = { bib } })
+    local response = complete(source, helpers.ctx('\\cite{alpha;bet', nil, bufnr))
+    assert.are.same({ 'alpha;beta' }, labels(response))
+  end)
+
+  it('still filters on the last key after a Pandoc semicolon', function()
+    local markdown = helpers.make_buf({ lines = { '' }, filetype = 'markdown' })
+    local source = Source.new({ files = { bib } })
+    local response = complete(source, helpers.ctx('[@alpha;beta; @bet', nil, markdown))
+    assert.are.same({ 'beta' }, labels(response))
+    vim.api.nvim_buf_delete(markdown, { force = true })
+  end)
+end)
+
 describe('Source entry lookup lifetime', function()
   local bufnr, dir, bib
 
@@ -436,6 +470,24 @@ describe('Source.__test.key_under_cursor', function()
 
   it('still stops at the delimiter that ends the citation', function()
     assert.are.equal('smith2020', detect('markdown', 'see [@smi|th2020] and more'))
+  end)
+
+  it('keeps a semicolon inside a LaTeX key', function()
+    -- LaTeX separates keys with commas; a semicolon is part of the key, and the
+    -- parser accepts it as one.
+    assert.are.equal('alpha;beta', detect('tex', '\\cite{alp|ha;beta}'))
+  end)
+
+  it('reads the key before a Pandoc semicolon separator', function()
+    assert.are.equal('key1', detect('markdown', 'see [@key|1; @key2] here'))
+  end)
+
+  it('reads the key after a Pandoc semicolon separator', function()
+    assert.are.equal('key2', detect('markdown', 'see [@key1; @key|2] here'))
+  end)
+
+  it('keeps a semicolon inside a GAPDoc key', function()
+    assert.are.equal('a;b', detect('gap', '<Cite Key="a|;b"/>'))
   end)
 
   it('returns nil for a plain word', function()

--- a/tests/source_spec.lua
+++ b/tests/source_spec.lua
@@ -420,6 +420,24 @@ describe('Source.__test.key_under_cursor', function()
     assert.are.equal('smith2020', detect('xml', '<Ref BibKey="smi|th2020"/>', opts))
   end)
 
+  it('keeps a slash inside the key', function()
+    assert.are.equal('smith/2020', detect('tex', '\\cite{smi|th/2020}'))
+  end)
+
+  it('keeps a plus inside a GAPDoc key', function()
+    assert.are.equal('a+b', detect('gap', '<Cite Key="a|+b"/>'))
+  end)
+
+  it('keeps punctuation the parser accepts in a key', function()
+    -- The parser takes any run of non-comma, non-whitespace characters, so the
+    -- cursor scan must not stop at the first character outside a short alphabet.
+    assert.are.equal('a/b+c~d!e', detect('tex', '\\cite{a/b|+c~d!e}'))
+  end)
+
+  it('still stops at the delimiter that ends the citation', function()
+    assert.are.equal('smith2020', detect('markdown', 'see [@smi|th2020] and more'))
+  end)
+
   it('returns nil for a plain word', function()
     assert.is_nil(detect('markdown', 'just some wo|rds here'))
   end)

--- a/tests/source_spec.lua
+++ b/tests/source_spec.lua
@@ -3,6 +3,7 @@
 local assert = require('luassert')
 local Source = require('blink-cmp-bibtex')
 local cache = require('blink-cmp-bibtex.cache')
+local config = require('blink-cmp-bibtex.config')
 local helpers = require('tests.helpers')
 
 --- Drive Source:get_completions synchronously.
@@ -358,5 +359,72 @@ describe('Source:execute auto_add', function()
     complete(source, helpers.ctx('\\cite{bbb', nil, bufnr))
     accept(source, 'aaa1')
     assert.is_truthy(read_target():find('@article{aaa1', 1, true))
+  end)
+end)
+
+describe('Source.__test.key_under_cursor', function()
+  local bufnr
+
+  --- Place the cursor in a scratch buffer and detect the key under it.
+  --- @param filetype string
+  --- @param line string Cursor position is marked with '|'
+  --- @param opts table|nil Configuration options
+  --- @return string|nil
+  local function detect(filetype, line, opts)
+    local col = assert(line:find('|', 1, true), 'the line must mark the cursor with |') - 1
+    bufnr = helpers.make_buf({ lines = { (line:gsub('%|', '')) }, filetype = filetype })
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.api.nvim_win_set_cursor(0, { 1, col })
+    return Source.__test.key_under_cursor(bufnr, opts or config.get())
+  end
+
+  after_each(function()
+    if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end)
+
+  it('detects a key the cursor sits inside of in a LaTeX citation', function()
+    assert.are.equal('smith2020', detect('tex', '\\cite{smi|th2020} and more'))
+  end)
+
+  it('detects a key the cursor sits at the end of', function()
+    assert.are.equal('smith2020', detect('tex', '\\cite{smith202|0}'))
+  end)
+
+  it('detects the key being pointed at in a multi-key citation', function()
+    assert.are.equal('doe2019', detect('tex', '\\cite{smith2020,do|e2019}'))
+  end)
+
+  it('detects a Pandoc key', function()
+    assert.are.equal('smith2020', detect('markdown', 'see [@smi|th2020] here'))
+  end)
+
+  it('detects a GAPDoc key, which the ad-hoc patterns never covered', function()
+    assert.are.equal('smith2020', detect('gap', '<Cite Key="smi|th2020"/>'))
+  end)
+
+  it('detects a key through a user-registered matcher', function()
+    local opts = vim.deepcopy(config.get())
+    opts.matchers = vim.deepcopy(opts.matchers)
+    opts.matchers.xml = {
+      refkey = {
+        priority = 5,
+        sanitize = false,
+        match = function(text)
+          local prefix = text:match('<Ref%s+BibKey="([^"]*)$')
+          return prefix and { prefix = prefix, trigger = 'refkey' } or nil
+        end,
+      },
+    }
+    assert.are.equal('smith2020', detect('xml', '<Ref BibKey="smi|th2020"/>', opts))
+  end)
+
+  it('returns nil for a plain word', function()
+    assert.is_nil(detect('markdown', 'just some wo|rds here'))
+  end)
+
+  it('returns nil once the citation is closed behind the cursor', function()
+    assert.is_nil(detect('tex', '\\cite{smith2020}|'))
   end)
 end)

--- a/tests/source_spec.lua
+++ b/tests/source_spec.lua
@@ -248,3 +248,115 @@ describe('Source:resolve', function()
     assert.are.equal(item, resolved)
   end)
 end)
+
+describe('Source entry lookup lifetime', function()
+  local bufnr, dir, bib
+
+  before_each(function()
+    dir = vim.fs.normalize(vim.fn.tempname())
+    vim.fn.mkdir(dir, 'p')
+    bib = vim.fs.joinpath(dir, 'refs.bib')
+    local entries = {}
+    for index = 1, 5 do
+      table.insert(entries, string.format('@article{aaa%d,\n  title = {A %d}\n}', index, index))
+      table.insert(entries, string.format('@article{bbb%d,\n  title = {B %d}\n}', index, index))
+    end
+    helpers.write_file(bib, table.concat(entries, '\n'))
+    cache.invalidate(bib)
+    bufnr = helpers.make_buf({ lines = { '' }, filetype = 'tex' })
+  end)
+
+  after_each(function()
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+    vim.fn.delete(dir, 'rf')
+  end)
+
+  it('keeps only the latest round in the lookup instead of accumulating keys', function()
+    local source = Source.new({ files = { bib } })
+    complete(source, helpers.ctx('\\cite{aaa', nil, bufnr))
+    assert.are.equal(5, vim.tbl_count(Source.get_entry_lookup()))
+
+    complete(source, helpers.ctx('\\cite{bbb', nil, bufnr))
+    local lookup = Source.get_entry_lookup()
+    assert.are.equal(5, vim.tbl_count(lookup))
+    assert.is_nil(lookup.aaa1, 'a key from the previous round is still in the current one')
+    assert.is_not_nil(lookup.bbb1)
+  end)
+
+  it('does not grow across many rounds', function()
+    local source = Source.new({ files = { bib } })
+    for _ = 1, 20 do
+      complete(source, helpers.ctx('\\cite{aaa', nil, bufnr))
+      complete(source, helpers.ctx('\\cite{bbb', nil, bufnr))
+    end
+    assert.are.equal(5, vim.tbl_count(Source.get_entry_lookup()))
+  end)
+end)
+
+describe('Source:execute auto_add', function()
+  local bufnr, dir, global_bib, target
+
+  --- Drive Source:execute synchronously.
+  --- @param source table
+  --- @param key string
+  local function accept(source, key)
+    local done = false
+    source:execute({ bufnr = bufnr }, { data = { key = key } }, function()
+      done = true
+    end, nil)
+    vim.wait(2000, function()
+      return done
+    end)
+    assert.is_true(done, 'execute never invoked its callback')
+  end
+
+  before_each(function()
+    dir = vim.fs.normalize(vim.fn.tempname())
+    vim.fn.mkdir(dir, 'p')
+    global_bib = vim.fs.joinpath(dir, 'global.bib')
+    target = vim.fs.joinpath(dir, 'local.bib')
+    helpers.write_file(global_bib, '@article{aaa1,\n  title = {A 1}\n}\n@article{bbb1,\n  title = {B 1}\n}')
+    helpers.write_file(target, '')
+    cache.invalidate(global_bib)
+    bufnr = helpers.make_buf({ lines = { '' }, filetype = 'tex' })
+  end)
+
+  after_each(function()
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+    vim.fn.delete(dir, 'rf')
+  end)
+
+  --- @return table
+  local function make_source()
+    return Source.new({
+      files = { global_bib },
+      global_files = { global_bib },
+      local_bib = { enabled = true, auto_add = true, target = target, notify_on_add = false },
+    })
+  end
+
+  --- @return string
+  local function read_target()
+    local fd = assert(io.open(target, 'r'))
+    local content = fd:read('*a')
+    fd:close()
+    return content
+  end
+
+  it('copies the accepted entry to the local bib', function()
+    local source = make_source()
+    complete(source, helpers.ctx('\\cite{aaa', nil, bufnr))
+    accept(source, 'aaa1')
+    assert.is_truthy(read_target():find('@article{aaa1', 1, true))
+  end)
+
+  it('still resolves the accepted entry when a new round has already run', function()
+    -- The round that produced the item is retained one generation, so an accept
+    -- that lands after the next round has started still finds its entry.
+    local source = make_source()
+    complete(source, helpers.ctx('\\cite{aaa', nil, bufnr))
+    complete(source, helpers.ctx('\\cite{bbb', nil, bufnr))
+    accept(source, 'aaa1')
+    assert.is_truthy(read_target():find('@article{aaa1', 1, true))
+  end)
+end)


### PR DESCRIPTION
Closes #25. Closes #26. Closes #27.

## Discovery hooks

Buffer bib discovery is now configuration-driven, mirroring the matcher API. The built-in extractors (`latex`, `yaml`, `typst`, `gapdoc`) became named entries in a new `discovery` module, and the `discovery` config table lets users register their own discovery functions per filetype, order them with `priority`, disable built-ins per filetype, or turn buffer discovery off entirely with `discovery = false`. Hooks are error-isolated, and `:checkhealth blink-cmp-bibtex` reports the resolved chains. Default behaviour is unchanged.

## Fixes

- The entry lookup is now bounded to two completion rounds instead of growing for the session's lifetime.
- `:BibTeXCopyToLocal` detects citation keys through the matcher chain, so custom syntaxes such as GAPDoc work when copying entries.