### PR TITLE
fix(discovery): keep a GAPDoc database name that already ends in .bib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .tests/
 .repro/
+tmp/

--- a/README.md
+++ b/README.md
@@ -435,9 +435,11 @@ Custom styles can be added by extending `require("blink-cmp-bibtex").setup()` wi
   respected.
 - Typst `#bibliography()` declarations are detected, including those in imported files via `#import` statements.
 - GAPDoc `<Bibliography Databases="manual, gapdoc"/>` declarations are scanned in
-  XML documents. Names are comma-separated and carry no `.bib` extension, which
-  is appended automatically; `.xml` (BibXMLext) databases are skipped, as are
-  declarations inside XML comments, CDATA sections and processing instructions.
+  XML documents. Names are comma-separated and usually carry no `.bib`
+  extension, which is then appended automatically; a name that already ends in
+  `.bib` is kept as written, matching GAPDoc's own lookup order. `.xml`
+  (BibXMLext) databases are skipped, as are declarations inside XML comments,
+  CDATA sections and processing instructions.
 - GAP packages are looked up outside the buffer: when a `gap`, `xml` or
   `autodoc` buffer declares no bibliography of its own, the package around it is
   located through its `PackageInfo.g`, and its `doc/` directory is read for the

--- a/lua/blink-cmp-bibtex/discovery.lua
+++ b/lua/blink-cmp-bibtex/discovery.lua
@@ -407,8 +407,9 @@ end
 --- The caller has already established that the document can hold one; this is
 --- the part that is worth the joins and the pattern work.
 --- @param lines string[] The document lines
---- @return string[] File names as written in the Databases attribute with
----   '.bib' appended; entries may carry a directory part and may contain dots
+--- @return string[] File names as written in the Databases attribute, with
+---   '.bib' appended to those that do not already end in it; entries may carry
+---   a directory part and may contain dots
 local function extract_gapdoc_databases(lines)
   -- Joined so that a declaration split across lines is still found.
   local text = strip_inactive_regions(table.concat(lines, '\n'))
@@ -431,10 +432,12 @@ local function extract_gapdoc_databases(lines)
     databases = databases and decode_xml_references(databases)
     for _, name in ipairs(databases and split_resources(databases) or {}) do
       -- BibXMLext databases carry their full .xml name and are skipped; every
-      -- other name is a BibTeX database, which the DTD defines as being
-      -- written without its .bib extension, so it is always appended.
+      -- other name is a BibTeX database. GAPDoc's ParseBibFiles tries the name
+      -- as written first and only then the name with '.bib' appended, so a
+      -- name that already ends in '.bib' is kept as written and only an
+      -- extensionless one has the extension appended.
       if not name:lower():match('%.xml$') then
-        resources[#resources + 1] = name .. '.bib'
+        resources[#resources + 1] = name:lower():match('%.bib$') and name or name .. '.bib'
       end
     end
     cursor = start_pos + #BIBLIOGRAPHY_TAG
@@ -457,8 +460,9 @@ local function has_bibliography_marker(lines)
 end
 
 --- @param lines string[] Buffer lines to search
---- @return string[] File names as written in the Databases attribute with '.bib'
----   appended; entries may carry a directory part and may contain dots
+--- @return string[] File names as written in the Databases attribute, with
+---   '.bib' appended to those that do not already end in it; entries may carry
+---   a directory part and may contain dots
 local function find_gapdoc_bibliography(lines)
   if not has_bibliography_marker(lines) then
     return {}

--- a/tests/gap_package_spec.lua
+++ b/tests/gap_package_spec.lua
@@ -138,6 +138,19 @@ describe('discovery.gap_package', function()
     end)
   end)
 
+  it('keeps a declared database name that already ends in .bib', function()
+    helpers.with_tmpdir(function(dir)
+      local root = make_package(dir, {
+        ['PackageInfo.g'] = package_info,
+        ['doc/_main.xml'] = '<Bibliography Databases="cryst.bib"/>\n',
+        ['lib/foo.gd'] = '',
+      })
+      assert.are.same({
+        vim.fs.joinpath(root, 'doc/cryst.bib'),
+      }, names(discovery.gap_package(ctx(vim.fs.joinpath(root, 'lib/foo.gd')))))
+    end)
+  end)
+
   it('reports the manual that declared a database, and nothing for the convention', function()
     helpers.with_tmpdir(function(dir)
       local root = make_package(dir, {

--- a/tests/scan_spec.lua
+++ b/tests/scan_spec.lua
@@ -49,9 +49,27 @@ describe('scan.find_bib_files_from_buffer built-in order', function()
     vim.api.nvim_buf_delete(bufnr, { force = true })
   end)
 
-  it('leaves a dotted GAPDoc name alone, which already carries its extension', function()
+  it('appends .bib to a dotted GAPDoc name that does not carry it', function()
     local bufnr = helpers.make_buf({ lines = { '<Bibliography Databases="refs.v2"/>' }, filetype = 'xml' })
     assert.are.same({ 'refs.v2.bib' }, scan.find_bib_files_from_buffer(bufnr))
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('keeps a GAPDoc name that already ends in .bib', function()
+    local bufnr = helpers.make_buf({ lines = { '<Bibliography Databases="refs.bib"/>' }, filetype = 'xml' })
+    assert.are.same({ 'refs.bib' }, scan.find_bib_files_from_buffer(bufnr))
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('keeps an upper-case GAPDoc .bib name as written', function()
+    local bufnr = helpers.make_buf({ lines = { '<Bibliography Databases="REFS.BIB"/>' }, filetype = 'xml' })
+    assert.are.same({ 'REFS.BIB' }, scan.find_bib_files_from_buffer(bufnr))
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('appends .bib only where it is missing in a mixed GAPDoc list', function()
+    local bufnr = helpers.make_buf({ lines = { '<Bibliography Databases="cryst.bib, other"/>' }, filetype = 'xml' })
+    assert.are.same({ 'cryst.bib', 'other.bib' }, scan.find_bib_files_from_buffer(bufnr))
     vim.api.nvim_buf_delete(bufnr, { force = true })
   end)
 
@@ -347,10 +365,18 @@ describe('scan.find_bib_files_from_buffer with GAPDoc declarations', function()
     assert.are.same({ 'references.v2.bib' }, discover({ '<Bibliography Databases="references.v2"/>' }))
   end)
 
-  it('appends .bib even to a name that already spells it out', function()
-    -- Characterizes the rule rather than second-guessing it: GAPDoc itself
-    -- appends .bib to whatever is written, so 'refs.bib' names refs.bib.bib.
-    assert.are.same({ 'refs.bib.bib' }, discover({ '<Bibliography Databases="refs.bib"/>' }))
+  it('keeps a name that already spells out .bib', function()
+    -- GAPDoc's ParseBibFiles tries the name as written before it tries the name
+    -- with .bib appended, so 'refs.bib' names refs.bib and not refs.bib.bib.
+    assert.are.same({ 'refs.bib' }, discover({ '<Bibliography Databases="refs.bib"/>' }))
+  end)
+
+  it('keeps an upper-case .bib name as written', function()
+    assert.are.same({ 'REFS.BIB' }, discover({ '<Bibliography Databases="REFS.BIB"/>' }))
+  end)
+
+  it('appends .bib only where it is missing in a list', function()
+    assert.are.same({ 'cryst.bib', 'other.bib' }, discover({ '<Bibliography Databases="cryst.bib, other"/>' }))
   end)
 
   describe('inactive regions', function()


### PR DESCRIPTION
GAPDoc `<Bibliography Databases="cryst.bib"/>` declarations had `.bib` appended a second time, so `:checkhealth` reported a missing `cryst.bib.bib`. GAPDoc's own `ParseBibFiles` tries the name as written first and only then appends `.bib`; the discovery now mirrors that and keeps a name that already ends in `.bib` (case-insensitive). Applies to both the `gapdoc` hook and `gap_package` (`_main.xml`).

Ref: #30